### PR TITLE
Revert "Makefile: optimize build for local cpu"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ S2E_BUILD:=$(CURDIR)
 RELEASE_BUILD_TYPE=RelWithDebInfo
 
 # corei7 avoids instructions not supported by VirtualBox. Use "native" instead
-# to optimize for your current CPU. Use x86-64 for minimum x64 support.
-BUILD_ARCH?=native
+# to optimize for your current CPU.
+BUILD_ARCH?=x86-64
 
-CFLAGS_ARCH:=-march=$(BUILD_ARCH)
-CXXFLAGS_ARCH:=-march=$(BUILD_ARCH)
+CFLAGS_ARCH:=-march=$(BUILD_ARCH) -mno-sse4.1
+CXXFLAGS_ARCH:=-march=$(BUILD_ARCH) -mno-sse4.1
 
 CXXFLAGS_DEBUG:=$(CXXFLAGS_ARCH)
 CXXFLAGS_RELEASE:=$(CXXFLAGS_ARCH)


### PR DESCRIPTION
This reverts commit dce155a3cf535592fb8606a81e270fff4170dd0e.