### PR TITLE
Fix a build error

### DIFF
--- a/tools/lib/Utils/Log.cpp
+++ b/tools/lib/Utils/Log.cpp
@@ -21,6 +21,7 @@
 /// SOFTWARE.
 ///
 
+#include <iostream>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/FileSystem.h>
 


### PR DESCRIPTION
std::ostream is defined in ostream, which is missing in this
source file.