### PR TITLE
libs2eplugins: optionally create test cases when forking states

### DIFF
--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/TestCaseGenerator.h
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/TestCaseGenerator.h
@@ -245,6 +245,7 @@ public:
     const ConcreteFileTemplates &getTemplates(S2EExecutionState *state) const;
 
 private:
+    sigc::connection m_stateForkConnection;
     sigc::connection m_stateKillConnection;
     sigc::connection m_linuxSegFaultConnection;
     sigc::connection m_windowsUserCrashConnection;
@@ -252,6 +253,8 @@ private:
 
     ExecutionTracer *m_tracer;
 
+    void onStateFork(S2EExecutionState *state, const std::vector<S2EExecutionState *> &newStates,
+                     const std::vector<klee::ref<klee::Expr>> &newConditions);
     void onStateKill(S2EExecutionState *state);
     void onSegFault(S2EExecutionState *state, uint64_t pid, uint64_t pc);
     void onWindowsUserCrash(S2EExecutionState *state, const WindowsUserModeCrash &desc);


### PR DESCRIPTION
Add an option ".generateOnStateFork" to the test-case generator (default false).
If enabled, a new test case with suffix "fork" is generated for each newly
forked execution state.