### PR TITLE
When download the llvm toolkits with 'wget', there will be an extra slash('/') in the URL path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 LLVM_VERSION=10.0.0
 LLVM_SRC=llvm-$(LLVM_VERSION).src.tar.xz
 LLVM_SRC_DIR=llvm-$(LLVM_VERSION).src
-LLVM_SRC_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VERSION)/
+LLVM_SRC_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VERSION)
 
 # The Python script should only return a single word - the suffix of the Clang
 # binary to download. If an error message is printed to stderr, the Makefile


### PR DESCRIPTION
[BUG state] $ wget [...skip...]/llvmorg-10.0.0//clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz.

So I wrote this patch.