### PR TITLE
klee: fixed path to solver logs

### DIFF
--- a/klee/lib/Solver/SolverFactory.cpp
+++ b/klee/lib/Solver/SolverFactory.cpp
@@ -105,8 +105,8 @@ DefaultSolverFactory::DefaultSolverFactory(const std::filesystem::path &outputDi
 
 std::filesystem::path DefaultSolverFactory::getOutputFileName(const std::string &fileName) const {
     std::filesystem::path ret;
-    ret += m_outputDir;
-    ret += fileName;
+    ret /= m_outputDir;
+    ret /= fileName;
     return ret;
 }
 


### PR DESCRIPTION
There was a missing slash, s2e-lastsolver.log.

Signed-off-by: Vitaly Chipounov <vitaly@cyberhaven.com>