### PR TITLE
replace `distro.linux_distribution()` with `distro.{name,version}()`

### DIFF
--- a/scripts/determine_clang_binary_suffix.py
+++ b/scripts/determine_clang_binary_suffix.py
@@ -81,7 +81,8 @@ def _get_ubuntu_version(version_string):
 
 def main():
     """The main function."""
-    name, version, _ = distro.linux_distribution()
+    name = distro.name()
+    version = distro.version()
 
     clang_ver_to_download = None
 


### PR DESCRIPTION
# Overview
* Distro/Verision: Ubuntu 20.04.3 LTS
* `distro.linux_distribution()` is deprecated, which causes build failure on newer ubuntu installation.

This PR fixes the issue.

# What's Wrong

```
$ s2e build
INFO: [build] Building S2E (release) in /home/aesophor/s2e/build
INFO: [sh.command] <Command '/usr/bin/make --directory=/home/aesophor/s2e/build --file=/home/aesophor/s2e/source/Makefile install', pid 52599>: process started
make: Entering directory '/home/aesophor/s2e/build'
/home/aesophor/s2e/source/scripts//..//s2e/Makefile:84: *** "Failed to determine Clang binary to download: /home/aesophor/s2e/source/s2e//..//s2e/scripts/determine_clang_binary_suffix.py:84: DeprecationWarning: distro.linux_distribution() is deprecated. It should only be used as a compatibility shim with Python's platform.linux_distribution(). Please use distro.id(), distro.version() and distro.name() instead.   name, version, _ = distro.linux_distribution() x86_64-linux-gnu-ubuntu-18.04".  Stop.
make: Leaving directory '/home/aesophor/s2e/build'
ERROR: [build]

  RAN: /usr/bin/make --directory=/home/aesophor/s2e/build --file=/home/aesophor/s2e/source/Makefile install

  STDOUT:


  STDERR:

```