### PR TITLE
klee,s2e: added support for fork() without symbolic conditions 

### DIFF
--- a/guest/common/include/s2e/s2e.h
+++ b/guest/common/include/s2e/s2e.h
@@ -336,20 +336,12 @@ static inline void s2e_disable_forking(void)
 /// \brief Forks the given number of times without adding constraints
 ///
 /// \param[in] count The number of times to fork
-/// \param[in] name Label
-/// \return ???
 ///
-static inline int s2e_fork(int count, const char *name) {
-    unsigned result = 0;
-    __s2e_touch_string(name);
+static inline void s2e_fork(int count) {
     __asm__ __volatile__(
         S2E_INSTRUCTION_SIMPLE(BASE_S2E_FORK_COUNT)
-        : "=a" (result) : "a" (count), "c" (name)
+        : : "a" (count)
     );
-
-    s2e_concretize(&result, sizeof(result));
-
-    return result;
 }
 
 ///

--- a/klee/include/klee/Executor.h
+++ b/klee/include/klee/Executor.h
@@ -223,6 +223,9 @@ public:
     virtual StatePair fork(ExecutionState &current, const ref<Expr> &condition,
                            bool keepConditionTrueInCurrentState = false);
 
+    // Unconditional fork
+    virtual StatePair fork(ExecutionState &current);
+
     // remove state from queue and delete
     virtual void terminateState(ExecutionState &state);
 

--- a/klee/include/klee/util/Assignment.h
+++ b/klee/include/klee/util/Assignment.h
@@ -74,6 +74,10 @@ public:
                                 bool _allowFreeValues = false) {
         return AssignmentPtr(new Assignment(objects, values, _allowFreeValues));
     }
+
+    static AssignmentPtr create(const AssignmentPtr &a) {
+        return AssignmentPtr(new Assignment(*a));
+    }
 };
 
 /***/

--- a/klee/lib/Core/Executor.cpp
+++ b/klee/lib/Core/Executor.cpp
@@ -450,6 +450,22 @@ Executor::StatePair Executor::fork(ExecutionState &current, const ref<Expr> &con
     return StatePair(trueState, falseState);
 }
 
+Executor::StatePair Executor::fork(ExecutionState &current) {
+    if (current.forkDisabled) {
+        return StatePair(&current, nullptr);
+    }
+
+    ExecutionState *clonedState;
+    notifyBranch(current);
+    clonedState = current.clone();
+    addedStates.insert(clonedState);
+
+    // Deep copy concolics.
+    clonedState->concolics = Assignment::create(current.concolics);
+
+    return StatePair(&current, clonedState);
+}
+
 void Executor::notifyFork(ExecutionState &originalState, ref<Expr> &condition, Executor::StatePair &targets) {
     // Should not get here
     pabort("Must go through S2E");

--- a/libs2ecore/include/s2e/S2EExecutor.h
+++ b/libs2ecore/include/s2e/S2EExecutor.h
@@ -86,6 +86,22 @@ public:
     StatePair fork(klee::ExecutionState &current, const klee::ref<klee::Expr> &condition,
                    bool keepConditionTrueInCurrentState = false);
 
+    // A special version of fork() which does not take any symbolic condition,
+    // so internally it will just work like the regular fork method
+    // except that no path constraints will be added.
+    //
+    // This method is useful when the user wants to explicitly clone a state
+    // in their plugin code and switch back to the cloned state later.
+    // Note that `current` state must be running in symbolic mode before it is
+    // passed to this method. To make sure your state is running in symbolic mode,
+    // do this before calling Executor::fork().
+    // ```
+    // if (state->needToJumpToSymbolic()) {
+    //     state->jumpToSymbolic();
+    // }
+    // ```
+    StatePair fork(klee::ExecutionState &current);
+
     void flushTb();
 
     /** Create initial execution state */
@@ -217,6 +233,11 @@ protected:
 
     void replaceExternalFunctionsWithSpecialHandlers();
     void disableConcreteLLVMHelpers();
+
+private:
+    // If `condition` is a nullptr, then no path constraints will be added.
+    StatePair doFork(klee::ExecutionState &current, const klee::ref<klee::Expr> *condition,
+                     bool keepConditionTrueInCurrentState);
 };
 
 } // namespace s2e

--- a/libs2ecore/src/S2EExecutor.cpp
+++ b/libs2ecore/src/S2EExecutor.cpp
@@ -1419,8 +1419,8 @@ S2EExecutor::StatePair S2EExecutor::doFork(ExecutionState &current, const klee::
         return res;
     }
 
-    std::vector<S2EExecutionState *> newStates(2);
-    std::vector<klee::ref<Expr>> newConditions(2);
+    llvm::SmallVector<S2EExecutionState *, 2> newStates;
+    llvm::SmallVector<klee::ref<Expr>, 2> newConditions;
 
     newStates[0] = static_cast<S2EExecutionState *>(res.first);
     newStates[1] = static_cast<S2EExecutionState *>(res.second);

--- a/libs2ecore/src/S2EExecutor.cpp
+++ b/libs2ecore/src/S2EExecutor.cpp
@@ -1370,15 +1370,28 @@ Executor::StatePair S2EExecutor::forkAndConcretize(S2EExecutionState *state, kle
 
 S2EExecutor::StatePair S2EExecutor::fork(ExecutionState &current, const klee::ref<Expr> &condition,
                                          bool keepConditionTrueInCurrentState) {
+    return doFork(current, &condition, keepConditionTrueInCurrentState);
+}
+
+S2EExecutor::StatePair S2EExecutor::fork(ExecutionState &current) {
+    return doFork(current, nullptr, false);
+}
+
+S2EExecutor::StatePair S2EExecutor::doFork(ExecutionState &current, const klee::ref<Expr> *condition,
+                                           bool keepConditionTrueInCurrentState) {
     S2EExecutionState *currentState = dynamic_cast<S2EExecutionState *>(&current);
     assert(currentState);
     assert(!currentState->isRunningConcrete());
 
     StatePair res;
 
-    // If the condition is constant, there is no need to do anything as the fork will not branch
+    // Check if we should fork the current state.
+    // 1. If no conditions are passed to us, then the user wants to explicitly
+    //    fork the current state, and thus we should perform the check.
+    // 2. If the condition is constant, there is no need to do anything
+    //    as the fork will not branch.
     bool forkOk = true;
-    if (!dyn_cast<klee::ConstantExpr>(condition)) {
+    if (!condition || !dyn_cast<klee::ConstantExpr>(*condition)) {
         if (currentState->forkDisabled) {
             g_s2e->getDebugStream(currentState) << "fork disabled at " << hexval(currentState->regs()->getPc()) << "\n";
         }
@@ -1394,7 +1407,11 @@ S2EExecutor::StatePair S2EExecutor::fork(ExecutionState &current, const klee::re
         currentState->forkDisabled = true;
     }
 
-    res = Executor::fork(current, condition, keepConditionTrueInCurrentState);
+    if (condition) {
+        res = Executor::fork(current, *condition, keepConditionTrueInCurrentState);
+    } else {
+        res = Executor::fork(current);
+    }
 
     currentState->forkDisabled = oldForkStatus;
 
@@ -1402,24 +1419,28 @@ S2EExecutor::StatePair S2EExecutor::fork(ExecutionState &current, const klee::re
         return res;
     }
 
-    S2EExecutionState *newStates[2];
+    std::vector<S2EExecutionState *> newStates(2);
+    std::vector<klee::ref<Expr>> newConditions(2);
+
     newStates[0] = static_cast<S2EExecutionState *>(res.first);
     newStates[1] = static_cast<S2EExecutionState *>(res.second);
 
-    klee::ref<Expr> newConditions[2];
-    newConditions[0] = condition;
-    newConditions[1] = klee::NotExpr::create(condition);
+    if (condition) {
+        newConditions[0] = *condition;
+        newConditions[1] = klee::NotExpr::create(*condition);
+    }
 
     llvm::raw_ostream &out = m_s2e->getInfoStream(currentState);
     out << "Forking state " << currentState->getID() << " at pc = " << hexval(currentState->regs()->getPc())
         << " at pagedir = " << hexval(currentState->regs()->getPageDir()) << '\n';
 
     for (unsigned i = 0; i < 2; ++i) {
-        if (VerboseFork) {
+        if (newStates[i]) {
             out << "    state " << newStates[i]->getID();
-            out << " with condition " << newConditions[i] << '\n';
-        } else {
-            out << "    state " << newStates[i]->getID() << "\n";
+            if (VerboseFork && condition) {
+                out << " with condition " << newConditions[i];
+            }
+            out << '\n';
         }
 
         // Handled in ::branch

--- a/testsuite/basic10-fork-no-constraint/Makefile
+++ b/testsuite/basic10-fork-no-constraint/Makefile
@@ -1,0 +1,46 @@
+# Copyright (c) 2021, Cyberhaven
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+TARGET=basic10-fork-no-constraint
+SOURCE=main.c
+
+GCC_LINUX=gcc
+GCC_WINDOWS64=x86_64-w64-mingw32-gcc
+GCC_WINDOWS32=i686-w64-mingw32-gcc
+
+CFLAGS:=$(CFLAGS) -O0 -g -Wall -std=c99
+
+linux64-$(TARGET): $(SOURCE)
+	$(GCC_LINUX) -m64 $(CFLAGS) -o "$@" "$^"
+
+linux32-$(TARGET): $(SOURCE)
+	$(GCC_LINUX) -m32 $(CFLAGS) -o "$@" "$^"
+
+windows64-$(TARGET).exe: $(SOURCE)
+	$(GCC_WINDOWS64) -m64 $(CFLAGS) -o "$@" "$^"
+
+windows32-$(TARGET).exe: $(SOURCE)
+	$(GCC_WINDOWS32) -m32 $(CFLAGS) -o "$@" "$^"
+
+TARGETS=linux64-$(TARGET) linux32-$(TARGET) windows64-$(TARGET).exe windows32-$(TARGET).exe
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)

--- a/testsuite/basic10-fork-no-constraint/config.yml
+++ b/testsuite/basic10-fork-no-constraint/config.yml
@@ -1,0 +1,8 @@
+test:
+    description: "Check that fork `count` times works properly"
+
+    targets:
+        - windows64-basic10-fork-no-constraint.exe
+        - windows32-basic10-fork-no-constraint.exe
+        - linux32-basic10-fork-no-constraint
+        - linux64-basic10-fork-no-constraint

--- a/testsuite/basic10-fork-no-constraint/main.c
+++ b/testsuite/basic10-fork-no-constraint/main.c
@@ -1,0 +1,43 @@
+// Copyright (c) 2021, Cyberhaven
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <s2e/s2e.h>
+
+static void test_fork_simple(void) {
+    int var = 1337;
+    s2e_make_symbolic(&var, sizeof(var), "var");
+
+    // Forks the current execution state without adding any path constraint
+    // Now there should be two identical execution states.
+    s2e_fork(1);
+
+    // Each of the two states should fork twice here,
+    // resulting in a total of four states.
+    if (var == 1337) {
+        s2e_printf("This is state %d here", s2e_get_path_id());
+    } else {
+        s2e_printf("This is state %d here", s2e_get_path_id());
+    }
+}
+
+int main(int argc, char **argv) {
+    test_fork_simple();
+    return 0;
+}

--- a/testsuite/basic10-fork-no-constraint/run-tests.tpl
+++ b/testsuite/basic10-fork-no-constraint/run-tests.tpl
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+{% include 'common-run.sh.tpl' %}
+
+s2e run -n {{ project_name }}
+
+# Make sure this test case generates exactly 4 states.
+grep -q "This is state 0 here" $S2E_LAST/debug.txt
+grep -q "This is state 1 here" $S2E_LAST/debug.txt
+grep -q "This is state 2 here" $S2E_LAST/debug.txt
+grep -q "This is state 3 here" $S2E_LAST/debug.txt
+
+check_coverage {{project_name}} 100.0


### PR DESCRIPTION
As discussed in [1] and [2], it would be useful if the user can
fork a state unconditionally in their plugin code and switch back to it later.

This commit introduces a new way to fork a state without specifying
symbolic conditions. Essentially, an overloaded version of
`klee::Executor::fork()` is added which works similarly to
the regular version but without any path constraint code.

Besides, an overloaded version of `S2EExecutor::fork()` is added,
so that when the user explicitly forks a state using the new API,
S2E can write debugging messages just like the regular version of
`S2EExecutor::fork()` does.

Finally, since the two versions of `S2EExecutor::fork()` shares
a lot of similarity, the actual forking work has been moved to
`S2EExecutor::doFork()` in order to avoid code duplication.

Reference:
[1] https://groups.google.com/g/s2e-dev/c/x8tDX8i_v5o/m/JmuWEA4rQTAJ
[2] https://groups.google.com/g/s2e-dev/c/SeBpMlyHx3A/m/QqeOUSguDnIJ

Signed-off-by: Marco Wang <m.aesophor@gmail.com>