### PR TITLE
klee/Ref: implemented operator bool()

### DIFF
--- a/klee/include/klee/util/Ref.h
+++ b/klee/include/klee/util/Ref.h
@@ -95,7 +95,11 @@ public:
     }
 
     bool isNull() const {
-        return ptr == 0;
+        return ptr == nullptr;
+    }
+
+    explicit operator bool() const noexcept {
+        return !isNull();
     }
 
     // assumes non-null arguments


### PR DESCRIPTION
This was implemented last year in upstream (https://github.com/klee/klee/commit/c763a4087f1d8fa4dbdfb9c8f30d545cdb66a0aa), which allows us to:

1. easily test whether a `klee::ref` holds a nullptr
2. do something like:
   ```cpp
   if (ref<ConstantExpr> ce = dyn_cast<ConstantExpr>(expr)) {
       // Do something with `ce`
   }
   ```

Signed-off-by: Marco Wang \<m.aesophor@gmail.com\>