### PR TITLE
libs2ecore: reuse `pointerSize` argument

### DIFF
--- a/libs2ecore/src/S2EExecutionState.cpp
+++ b/libs2ecore/src/S2EExecutionState.cpp
@@ -714,7 +714,7 @@ bool S2EExecutionState::disassemble(llvm::raw_ostream &os, uint64_t pc, unsigned
 
 bool S2EExecutionState::disassemble(llvm::raw_ostream &os, uint64_t pc, unsigned size, unsigned pointerSize) {
     int flags = 0; // 32-bit code by default
-    switch (getPointerSize()) {
+    switch (pointerSize) {
         case 4:
             flags = 0;
             break;


### PR DESCRIPTION
Signed-off-by: Marco Wang \<m.aesophor@gmail.com\>