### PR TITLE
libs2ecore,libs2eplugins: emit condition onStateForkDecide

### DIFF
--- a/libs2ecore/include/s2e/CorePlugin.h
+++ b/libs2ecore/include/s2e/CorePlugin.h
@@ -373,7 +373,8 @@ public:
     ///
     sigc::signal<void,
                  S2EExecutionState*,
-                 bool* /* allow forking */>
+                 const klee::ref<klee::Expr>& /*condition*/,
+                 bool& /* allow forking */>
         onStateForkDecide;
 
 

--- a/libs2ecore/include/s2e/S2EExecutor.h
+++ b/libs2ecore/include/s2e/S2EExecutor.h
@@ -236,7 +236,7 @@ protected:
 
 private:
     // If `condition` is a nullptr, then no path constraints will be added.
-    StatePair doFork(klee::ExecutionState &current, const klee::ref<klee::Expr> *condition,
+    StatePair doFork(klee::ExecutionState &current, const klee::ref<klee::Expr> &condition,
                      bool keepConditionTrueInCurrentState);
 };
 

--- a/libs2eplugins/src/s2e/Plugins/Lua/LuaCoreEvents.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Lua/LuaCoreEvents.cpp
@@ -73,7 +73,8 @@ void LuaCoreEvents::registerCoreSignals(const std::string &cfgname) {
     }
 }
 
-void LuaCoreEvents::onStateForkDecide(S2EExecutionState *state, bool *allowForking) {
+void LuaCoreEvents::onStateForkDecide(S2EExecutionState *state, const klee::ref<klee::Expr> &condition,
+                                      bool &allowForking) {
     lua_State *L = s2e()->getConfig()->getState();
     LuaS2EExecutionState luaS2EState(state);
     LuaInstrumentationState luaInstrumentation;
@@ -83,10 +84,10 @@ void LuaCoreEvents::onStateForkDecide(S2EExecutionState *state, bool *allowForki
     Lunar<LuaInstrumentationState>::push(L, &luaInstrumentation);
 
     lua_call(L, 2, 1);
-    *allowForking = lua_toboolean(L, -1) != 0;
+    allowForking = lua_toboolean(L, -1) != 0;
     lua_pop(L, 1);
 
-    if (!*allowForking) {
+    if (!allowForking) {
         s2e()->getInfoStream() << "instrumentation prevented forking at pc=" << hexval(state->regs()->getPc()) << "\n";
     }
 }

--- a/libs2eplugins/src/s2e/Plugins/Lua/LuaCoreEvents.h
+++ b/libs2eplugins/src/s2e/Plugins/Lua/LuaCoreEvents.h
@@ -52,7 +52,7 @@ private:
 
     void onTimer();
     void onStateKill(S2EExecutionState *state);
-    void onStateForkDecide(S2EExecutionState *state, bool *allowForking);
+    void onStateForkDecide(S2EExecutionState *state, const klee::ref<klee::Expr> &condition, bool &allowForking);
 };
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/PathLimiters/ForkLimiter.cpp
+++ b/libs2eplugins/src/s2e/Plugins/PathLimiters/ForkLimiter.cpp
@@ -58,7 +58,8 @@ void ForkLimiter::initialize() {
     m_timerTicks = 0;
 }
 
-void ForkLimiter::onStateForkDecide(S2EExecutionState *state, bool *doFork) {
+void ForkLimiter::onStateForkDecide(S2EExecutionState *state, const klee::ref<klee::Expr> &condition,
+                                    bool &allowForking) {
     auto module = m_detector->getCurrentDescriptor(state);
     if (!module) {
         return;
@@ -71,7 +72,7 @@ void ForkLimiter::onStateForkDecide(S2EExecutionState *state, bool *doFork) {
     }
 
     if (m_forkCount[module->Name][curPc] > m_limit) {
-        *doFork = false;
+        allowForking = false;
     }
 }
 

--- a/libs2eplugins/src/s2e/Plugins/PathLimiters/ForkLimiter.h
+++ b/libs2eplugins/src/s2e/Plugins/PathLimiters/ForkLimiter.h
@@ -55,7 +55,8 @@ private:
     void onTimer();
     void onProcessForkDecide(bool *proceed);
 
-    void onStateForkDecide(S2EExecutionState *state, bool *doFork);
+    void onStateForkDecide(S2EExecutionState *state, const klee::ref<klee::Expr> &condition, bool &allowForking);
+
     void onFork(S2EExecutionState *state, const std::vector<S2EExecutionState *> &newStates,
                 const std::vector<klee::ref<klee::Expr>> &newConditions);
 };

--- a/libs2eplugins/src/s2e/Plugins/PathLimiters/ResourceMonitor.cpp
+++ b/libs2eplugins/src/s2e/Plugins/PathLimiters/ResourceMonitor.cpp
@@ -201,12 +201,13 @@ bool ResourceMonitor::memoryLimitExceeded() {
     }
 }
 
-void ResourceMonitor::onStateForkDecide(S2EExecutionState *state, bool *doFork) {
+void ResourceMonitor::onStateForkDecide(S2EExecutionState *state, const klee::ref<klee::Expr> &condition,
+                                        bool &allowForking) {
     // Do not set the value to true, it is true by default.
     // Plugins can set it to false if they want to change the behavior without
     // interfering with each other.
     if (memoryLimitExceeded()) {
-        *doFork = false;
+        allowForking = false;
     }
 }
 

--- a/libs2eplugins/src/s2e/Plugins/PathLimiters/ResourceMonitor.h
+++ b/libs2eplugins/src/s2e/Plugins/PathLimiters/ResourceMonitor.h
@@ -49,7 +49,7 @@ private:
     std::string m_memStatFileName;
     S2ESynchronizedObject<bool> m_notifiedQMP;
 
-    void onStateForkDecide(S2EExecutionState *state, bool *doFork);
+    void onStateForkDecide(S2EExecutionState *state, const klee::ref<klee::Expr> &condition, bool &allowForking);
     void onTimer(void);
     void updateMemoryUsage();
     bool memoryLimitExceeded();


### PR DESCRIPTION
This gives the user the ability to inspect the branch condition
before they decide whether the state fork should be allowed.

Signed-off-by: Marco Wang \<m.aesophor@gmail.com>