### PR TITLE
libs2eplugins/IntervalMapWrapper: remove outdated comment

### DIFF
--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/IntervalMapWrapper.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/IntervalMapWrapper.h
@@ -48,10 +48,7 @@ public:
     using iterator = typename IM::iterator;
 
 private:
-    // This cannot be a non-static variable because it's used by the
-    // parent class but would be destroyed first, causing corruptions.
     typename IM::Allocator m_alloc;
-
     IM m_map;
 
 public:


### PR DESCRIPTION
The llvm::IntervalMap's allocator is now destroyed after the IntervalMap itself.

Signed-off-by: Marco Wang \<m.aesophor@gmail.com>