### PR TITLE
libs2ecore/S2EExecutionState: remove makeSymbolic()

### DIFF
--- a/libs2ecore/include/s2e/S2EExecutionState.h
+++ b/libs2ecore/include/s2e/S2EExecutionState.h
@@ -269,9 +269,6 @@ public:
         m_memIoVaddr = value;
     }
 
-    /** Handler for tcg_llvm_get_value. */
-    void makeSymbolic(std::vector<klee::ref<klee::Expr>> &args);
-
     bool getReturnAddress(uint64_t *retAddr);
     bool bypassFunction(unsigned paramCount);
 


### PR DESCRIPTION
Because it is not used anymore.

Signed-off-by: Marco Wang \<m.aesophor@gmail.com\>