### PR TITLE
Use prebuilt packages for LLVM and Z3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,31 +27,39 @@ RUN sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt bionic main restricted
     sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt bionic-updates main restricted' /etc/apt/sources.list && \
     sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt bionic-security main restricted' /etc/apt/sources.list
 
+
+
 # Install build dependencies
 RUN dpkg --add-architecture i386 && apt-get update &&                       \
-    apt-get -y install build-essential cmake wget texinfo flex bison        \
+    apt-get -y install build-essential wget texinfo flex bison        \
     python-dev python3-dev python3-venv python3-distro mingw-w64            \
-    lsb-release libgomp1 unzip
+    lsb-release libgomp1 unzip libedit-dev libxml2-dev
+
+# We need a new-ish cmake to deal with LLVM-13 binary packages since the
+# default on 18.0 is too old. Use latest as of this writing.
+RUN wget -O cmake.sh https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-Linux-x86_64.sh && \
+    sh ./cmake.sh --prefix=/usr/local --skip-license
 
 # Install S2E dependencies
 RUN apt-get update && apt-get -y install libdwarf-dev libelf-dev libelf-dev:i386 \
-    libboost-dev zlib1g-dev libjemalloc-dev nasm pkg-config                 \
-    libmemcached-dev libpq-dev libc6-dev-i386 binutils-dev                  \
-    libboost-system-dev libboost-serialization-dev libboost-regex-dev       \
-    libbsd-dev libpixman-1-dev                                              \
-    libglib2.0-dev libglib2.0-dev:i386 python3-docutils libpng-dev gcc-multilib g++-multilib
+    libboost-dev zlib1g-dev libjemalloc-dev nasm pkg-config                    \
+    libmemcached-dev libpq-dev libc6-dev-i386 binutils-dev                     \
+    libboost-system-dev libboost-serialization-dev libboost-regex-dev          \
+    libbsd-dev libpixman-1-dev                                                 \
+    libglib2.0-dev libglib2.0-dev:i386 python3-docutils libpng-dev libpfm4-dev \
+    gcc-multilib g++-multilib
 
 # Required for C++17
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt update
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-9 g++-9
 
 # Install LLVM and Z3 binary packages to avoid building LLVM from source
 ENV SYSTEM_LLVM=13 USE_Z3_BINARY=yes
 RUN wget https://apt.llvm.org/llvm.sh && \
     chmod +x ./llvm.sh && \
-    ./llvm.sh ${SYSTEM_LLVM} && \
-    apt-get install libmlir-13-dev
+    DEBIAN_FRONTEND=noninteractive ./llvm.sh ${SYSTEM_LLVM} && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq libmlir-13-dev
 
 # Install S2E git
 RUN apt-get -y install git
@@ -72,7 +80,7 @@ RUN cd s2e-build &&                                                         \
     make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/soci-make
 
 RUN cd s2e-build &&                                                         \
-    make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/z3                   \
+    make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/z3
 
 RUN cd s2e-build &&                                                         \
     make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/protobuf-make

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt bionic main restricted
 # Install build dependencies
 RUN dpkg --add-architecture i386 && apt-get update &&                       \
     apt-get -y install build-essential cmake wget texinfo flex bison        \
-    python-dev python3-dev python3-venv python3-distro mingw-w64 lsb-release
+    python-dev python3-dev python3-venv python3-distro mingw-w64            \
+    lsb-release libgomp1
 
 # Install S2E dependencies
 RUN apt-get update && apt-get -y install libdwarf-dev libelf-dev libelf-dev:i386 \
@@ -44,6 +45,12 @@ RUN apt-get update && apt-get -y install libdwarf-dev libelf-dev libelf-dev:i386
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-9 g++-9
+
+# Install LLVM and Z3 binary packages to avoid building LLVM from source
+ENV SYSTEM_LLVM=13 USE_Z3_BINARY=yes
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x ./llvm.sh && \
+    ./llvm.sh ${SYSTEM_LLVM}
 
 # Install S2E git
 RUN apt-get -y install git

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt bionic main restricted
 RUN dpkg --add-architecture i386 && apt-get update &&                       \
     apt-get -y install build-essential cmake wget texinfo flex bison        \
     python-dev python3-dev python3-venv python3-distro mingw-w64            \
-    lsb-release libgomp1
+    lsb-release libgomp1 unzip
 
 # Install S2E dependencies
 RUN apt-get update && apt-get -y install libdwarf-dev libelf-dev libelf-dev:i386 \
@@ -50,7 +50,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-9 g++-9
 ENV SYSTEM_LLVM=13 USE_Z3_BINARY=yes
 RUN wget https://apt.llvm.org/llvm.sh && \
     chmod +x ./llvm.sh && \
-    ./llvm.sh ${SYSTEM_LLVM}
+    ./llvm.sh ${SYSTEM_LLVM} && \
+    apt-get install libmlir-13-dev
 
 # Install S2E git
 RUN apt-get -y install git
@@ -71,7 +72,7 @@ RUN cd s2e-build &&                                                         \
     make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/soci-make
 
 RUN cd s2e-build &&                                                         \
-    make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/z3-make
+    make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/z3                   \
 
 RUN cd s2e-build &&                                                         \
     make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/protobuf-make

--- a/Makefile
+++ b/Makefile
@@ -414,13 +414,14 @@ $(Z3_BINARY):
 	wget -O "$@" $(Z3_BINARY_URL)/$@
 
 stamps/z3-binary: $(Z3_BINARY) | stamps
-	unzip $<
+	unzip -qqo $<
 	mkdir -p $(S2E_PREFIX)
 	mkdir -p $(S2E_PREFIX)/include
 	mkdir -p $(S2E_PREFIX)/lib
 	mkdir -p $(S2E_PREFIX)/bin
 	cp -r $(Z3_BINARY_DIR)/include/* $(S2E_PREFIX)/include/
-	cp $(Z3_BINARY_DIR)/bin/*.{a,so} $(S2E_PREFIX)/lib/
+	cp $(Z3_BINARY_DIR)/bin/*.a $(S2E_PREFIX)/lib/
+	cp $(Z3_BINARY_DIR)/bin/*.so $(S2E_PREFIX)/lib/
 	cp $(Z3_BINARY_DIR)/bin/z3 $(S2E_PREFIX)/bin/
 	rm -r $(Z3_BINARY_DIR)/*
 	touch $@

--- a/klee/CMakeLists.txt
+++ b/klee/CMakeLists.txt
@@ -264,9 +264,13 @@ endif()
 ###############################################################################
 # Exception handling
 ###############################################################################
-if (NOT LLVM_ENABLE_EH)
-  klee_component_add_cxx_flag("-fno-exceptions" REQUIRED)
-endif()
+# This is commented out since it is incomparible with pre-packaged LLVM
+# that comes with exceptions off. While not a perfect solution, there should
+# not be that many issues since even a no-EH LLVM links against a libc++
+# with EH enabled, so the exceptions *within KLEE itself* should still be fine
+#if (NOT LLVM_ENABLE_EH)
+#  klee_component_add_cxx_flag("-fno-exceptions" REQUIRED)
+#endif()
 
 
 ################################################################################

--- a/libs2e/CMakeLists.txt
+++ b/libs2e/CMakeLists.txt
@@ -86,6 +86,9 @@ message(STATUS "Found libvmi ${VMI_PACKAGE_VERSION}")
 find_package(LIBCOROUTINE REQUIRED)
 message(STATUS "Found libcoroutine ${LIBCOROUTINE_PACKAGE_VERSION}")
 
+find_package(LibXml2 REQUIRED)
+message(STATUS "Found libxml2 ${LIBXML2_PACKAGE_VERSION}")
+
 if(WITH_TARGET MATCHES "s2e")
     # TODO: look at libcpu compile options to figure this out
     find_package(LIBS2ECORE REQUIRED)

--- a/libs2ecore/src/S2E.cpp
+++ b/libs2ecore/src/S2E.cpp
@@ -34,7 +34,6 @@
 #include <s2e/S2EExecutor.h>
 #include <s2e/Utils.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>

--- a/libs2ecore/src/S2EExecutor.cpp
+++ b/libs2ecore/src/S2EExecutor.cpp
@@ -47,7 +47,6 @@
 #include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/Process.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
 

--- a/libs2eplugins/src/s2e/Plugins/Core/HostFiles.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Core/HostFiles.cpp
@@ -36,7 +36,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
 

--- a/libs2eplugins/src/s2e/Plugins/Core/Vmi.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Core/Vmi.cpp
@@ -27,7 +27,6 @@
 #include <s2e/cpu.h>
 
 #include <iostream>
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 
 #include "Vmi.h"


### PR DESCRIPTION
Hi,

This PR  will allow the (optional) use of pre-built LLVM and Z3 packages instead of building these tools from source. It should greatly speed up build/ci times.

LLVM is expected to be pre-installed by the user as a system package (the Dockerfile was modified to fetch LLVM-13 from LLVM's apt repo).

The specific version of Z3 used is fetched as a binary release from the Z3 github page.

Should fix s2e-env/#454