### PR TITLE
makefile,dockerfile: Support using binary Z3 distributions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt bionic main restricted
 
 # Install build dependencies
 RUN dpkg --add-architecture i386 && apt-get update &&                       \
-    apt-get -y install build-essential cmake wget texinfo flex bison        \
+    apt-get -y install build-essential wget texinfo flex bison              \
     python-dev python3-dev python3-venv python3-distro mingw-w64 lsb-release
 
 # Install S2E dependencies
@@ -38,7 +38,10 @@ RUN apt-get update && apt-get -y install libdwarf-dev libelf-dev libelf-dev:i386
     libmemcached-dev libpq-dev libc6-dev-i386 binutils-dev                  \
     libboost-system-dev libboost-serialization-dev libboost-regex-dev       \
     libbsd-dev libpixman-1-dev                                              \
-    libglib2.0-dev libglib2.0-dev:i386 python3-docutils libpng-dev gcc-multilib g++-multilib
+    libglib2.0-dev libglib2.0-dev:i386 python3-docutils libpng-dev          \
+    gcc-multilib g++-multilib libgomp1 unzip
+# The unzip and libgomp1 dependencies are needed to unzip and run binary Z3
+# distributions
 
 # Required for C++17
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
@@ -47,6 +50,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-9 g++-9
 
 # Install S2E git
 RUN apt-get -y install git
+
+# CMake 3.13.4 or higher is required to build LLVM-13 from source.
+# Ubuntu 18.04 comes with cmake 3.10.2
+# Install the latest cmake (as of this writing)
+RUN wget -O cmake.sh https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-Linux-x86_64.sh && \
+    sh ./cmake.sh --prefix=/usr/local --skip-license
 
 # Build LLVM first (to avoid rebuilding it for every change)
 RUN mkdir s2e
@@ -59,12 +68,15 @@ RUN cd s2e-build &&                                                         \
 RUN cd s2e-build &&                                                         \
     make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/llvm-release-make
 
+# Be explicit about not building Z3 from source, even though its default
+ENV USE_Z3_BINARY=yes
+
 # Build S2E dependencies
 RUN cd s2e-build &&                                                         \
     make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/soci-make
 
 RUN cd s2e-build &&                                                         \
-    make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/z3-make
+    make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/z3
 
 RUN cd s2e-build &&                                                         \
     make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/protobuf-make

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@
 #      Contains llvm-release, llvm-debug, and llvm source folders
 #      Can be used to avoid rebuilding clang/llvm for every branch of S2E
 #
+#  USE_Z3_BINARY=yes
+#      Whether to use the Z3 binary or to build Z3 from source
+#
 
 # Check the build directory
 ifeq ($(shell ls libs2e/src/libs2e.c 2>&1),libs2e/src/libs2e.c)
@@ -27,6 +30,9 @@ BUILD_SCRIPTS_SRC?=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))/scripts
 S2E_SRC?=$(realpath $(BUILD_SCRIPTS_SRC)/../)
 S2E_PREFIX?=$(CURDIR)/opt
 S2E_BUILD:=$(CURDIR)
+
+# Build Z3 from binary (default, "yes") or source ("no")
+USE_Z3_BINARY?=yes
 
 # Either choose Release or RelWithDebInfo
 RELEASE_BUILD_TYPE=RelWithDebInfo
@@ -110,6 +116,9 @@ Z3_SRC=z3-$(Z3_VERSION).tar.gz
 Z3_SRC_DIR=z3-z3-$(Z3_VERSION)
 Z3_BUILD_DIR=z3
 Z3_URL=https://github.com/Z3Prover/z3
+Z3_BINARY_URL=https://github.com/Z3Prover/z3/releases/download/z3-$(Z3_VERSION)/
+Z3_BINARY=z3-$(Z3_VERSION)-x64-ubuntu-16.04.zip
+Z3_BINARY_DIR=z3-$(Z3_VERSION)-x64-ubuntu-16.04
 
 # Lua variables
 LUA_VERSION=5.3.4
@@ -380,6 +389,30 @@ stamps/z3-make: stamps/z3-configure
 	$(MAKE) -C $(Z3_BUILD_DIR) install
 	touch $@
 
+$(Z3_BINARY):
+	wget -O "$@" $(Z3_BINARY_URL)/$@
+
+stamps/z3-binary: $(Z3_BINARY) | stamps
+	unzip -qqo $<
+	mkdir -p $(S2E_PREFIX)
+	mkdir -p $(S2E_PREFIX)/include
+	mkdir -p $(S2E_PREFIX)/lib
+	mkdir -p $(S2E_PREFIX)/bin
+	cp -r $(Z3_BINARY_DIR)/include/* $(S2E_PREFIX)/include/
+	cp $(Z3_BINARY_DIR)/bin/*.a $(S2E_PREFIX)/lib/
+	cp $(Z3_BINARY_DIR)/bin/*.so $(S2E_PREFIX)/lib/
+	cp $(Z3_BINARY_DIR)/bin/z3 $(S2E_PREFIX)/bin/
+	rm -r $(Z3_BINARY_DIR)/*
+	touch $@
+
+ifeq ($(USE_Z3_BINARY),no)
+stamps/z3: stamps/z3-make
+	touch $@
+else
+stamps/z3: stamps/z3-binary
+	touch $@
+endif
+
 ############
 # Capstone #
 ############
@@ -493,14 +526,14 @@ KLEE_CONFIGURE_FLAGS = -DCMAKE_INSTALL_PREFIX=$(S2E_PREFIX)                     
                        -DZ3_INCLUDE_DIRS=$(S2E_PREFIX)/include                              \
                        -DZ3_LIBRARIES=$(S2E_PREFIX)/lib/libz3.a
 
-stamps/klee-debug-configure: stamps/llvm-debug-make stamps/z3-make stamps/gtest-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/klee)
+stamps/klee-debug-configure: stamps/llvm-debug-make stamps/z3 stamps/gtest-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/klee)
 stamps/klee-debug-configure: CONFIGURE_COMMAND = cmake $(KLEE_CONFIGURE_FLAGS)                      \
                                                  -DCMAKE_BUILD_TYPE=Debug                           \
                                                  -DLLVM_DIR=$(LLVM_BUILD)/llvm-debug/lib/cmake/llvm \
                                                  -DCMAKE_CXX_FLAGS="$(CXXFLAGS_DEBUG) -fno-omit-frame-pointer -fPIC" \
                                                  $(S2E_SRC)/klee
 
-stamps/klee-release-configure: stamps/llvm-release-make stamps/z3-make stamps/gtest-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/klee)
+stamps/klee-release-configure: stamps/llvm-release-make stamps/z3 stamps/gtest-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/klee)
 stamps/klee-release-configure: CONFIGURE_COMMAND = cmake $(KLEE_CONFIGURE_FLAGS)                        \
                                                    -DCMAKE_BUILD_TYPE=$(RELEASE_BUILD_TYPE)             \
                                                    -DLLVM_DIR=$(LLVM_BUILD)/llvm-release/lib/cmake/llvm \


### PR DESCRIPTION
Adds support for building S2E against a binary distribution of Z3
and makes it the default option.

The dockerfile is updated to install libgomp1 and unzip (to run and
install a binary Z3 distribution), and to download and install a
recent version of CMake, which was necessary to build LLVM 13 from
source, so that these changes could be tested.