### PR TITLE
Use binary LLVM-13

### DIFF
--- a/klee/CMakeLists.txt
+++ b/klee/CMakeLists.txt
@@ -264,9 +264,13 @@ endif()
 ###############################################################################
 # Exception handling
 ###############################################################################
-if (NOT LLVM_ENABLE_EH)
-  klee_component_add_cxx_flag("-fno-exceptions" REQUIRED)
-endif()
+# This is commented out since it is incomparible with pre-packaged LLVM
+# that comes with exceptions off. While not a perfect solution, there should
+# not be that many issues since even a no-EH LLVM links against a libc++
+# with EH enabled, so the exceptions *within KLEE itself* should still be fine
+#if (NOT LLVM_ENABLE_EH)
+#  klee_component_add_cxx_flag("-fno-exceptions" REQUIRED)
+#endif()
 
 
 ################################################################################

--- a/libs2e/CMakeLists.txt
+++ b/libs2e/CMakeLists.txt
@@ -61,7 +61,10 @@ add_definitions(${LLVM_DEFINITIONS})
 include_directories("include" ${LLVM_INCLUDE_DIRS})
 
 # llvm_map_components_to_libnames(LLVM_LIBS all) produces empty output for some reason
-set(LLVM_LIBS ${LLVM_AVAILABLE_LIBS})
+# Get a list of all LLVM static libraries to link against
+execute_process(COMMAND "${LLVM_TOOLS_BINARY_DIR}/llvm-config" --link-static --libfiles
+  OUTPUT_VARIABLE LLVM_LIBS)
+separate_arguments(LLVM_LIBS)
 
 ##################
 

--- a/libs2ecore/src/S2E.cpp
+++ b/libs2ecore/src/S2E.cpp
@@ -34,7 +34,6 @@
 #include <s2e/S2EExecutor.h>
 #include <s2e/Utils.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>

--- a/libs2ecore/src/S2EExecutor.cpp
+++ b/libs2ecore/src/S2EExecutor.cpp
@@ -47,7 +47,6 @@
 #include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/Process.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
 

--- a/libs2eplugins/src/s2e/Plugins/Core/HostFiles.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Core/HostFiles.cpp
@@ -36,7 +36,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
 

--- a/libs2eplugins/src/s2e/Plugins/Core/Vmi.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Core/Vmi.cpp
@@ -27,7 +27,6 @@
 #include <s2e/cpu.h>
 
 #include <iostream>
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 
 #include "Vmi.h"


### PR DESCRIPTION
Builds S2E against a binary LLVM-13 distribution. 

For the S2E demo to work, https://github.com/S2E/scripts/pull/5 should be merged first.