### PR TITLE
libtcg: fixed symbol lookup error

### DIFF
--- a/libtcg/include/tcg/tcg-op.h
+++ b/libtcg/include/tcg/tcg-op.h
@@ -35,6 +35,10 @@
 
 /* Basic output routines.  Not for general consumption.  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tcg_gen_op1(TCGOpcode, TCGArg);
 void tcg_gen_op2(TCGOpcode, TCGArg, TCGArg);
 void tcg_gen_op3(TCGOpcode, TCGArg, TCGArg, TCGArg);
@@ -1082,5 +1086,9 @@ static inline void tcg_gen_trunc_ptr_i32(TCGv_i32 r, TCGv_ptr a) {
 
 #undef PTR
 #undef NAT
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TCG_TCG_OP_H */


### PR DESCRIPTION
## Overview
Host OS: Ubuntu 20.04.4 LTS

This PR resolves a symbol lookup error mentioned in: https://groups.google.com/g/s2e-dev/c/JOSLbot_JFw

## Problem Description
In libs2ecore/src/CorePluginInterface.cpp, the function `s2e_tcg_instrument_code()` calls an inline function `tcg_gen_st_i64()`, and this inline function will be eventually replaced with `tcg_gen_op3()`.

The prototype of `tcg_gen_op3()` is from tcg/tcg-op.h, and since CorePluginInterface.cpp includes this header without extern "C", the call to tcg_gen_op3() becomes mangled (i.e. `call _Z11tcg_gen_op39TCGOpcodemmm@plt`), leading to symbol lookup error at runtime.

## Proposed Solution

In tcg/tcg-op.h, conditionally wrap the function prototypes with `extern "C"` when __cplusplus is defined.

Signed-off-by: Marco Wang \<m.aesophor@gmail.com\>