### PR TITLE
klee: Eliminate code duplication in Executor::fork()

### DIFF
--- a/klee/lib/Core/ExecutionState.cpp
+++ b/klee/lib/Core/ExecutionState.cpp
@@ -482,19 +482,16 @@ ref<Expr> ExecutionState::toUnique(ref<Expr> &e) {
 }
 
 bool ExecutionState::solve(const ConstraintManager &mgr, Assignment &assignment) {
-    ArrayVec symbObjects;
-    for (unsigned i = 0; i < symbolics.size(); ++i) {
-        symbObjects.push_back(symbolics[i]);
-    }
-
     std::vector<std::vector<unsigned char>> concreteObjects;
-    if (!solver()->getInitialValues(Query(mgr, ConstantExpr::alloc(0, Expr::Bool)), symbObjects, concreteObjects)) {
+    Query q(mgr, ConstantExpr::alloc(0, Expr::Bool));
+
+    if (!solver()->getInitialValues(q, symbolics, concreteObjects)) {
         return false;
     }
 
     assignment.clear();
-    for (unsigned i = 0; i < symbObjects.size(); ++i) {
-        assignment.add(symbObjects[i], concreteObjects[i]);
+    for (unsigned i = 0; i < symbolics.size(); ++i) {
+        assignment.add(symbolics[i], concreteObjects[i]);
     }
 
     return true;


### PR DESCRIPTION
Hello, Vitaly!

I've spotted code duplication in klee::Executor::fork(), so I tried eliminating them
by reusing the code in klee::ExecutionState::solve().

Signed-off-by: Marco Wang \<m.aesophor@gmail.com\>