### PR TITLE
makefile: change lua download link to use SSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ endif
 
 # Download Lua
 $(LUA_SRC):
-	$(call DOWNLOAD,http://www.lua.org/ftp/$(LUA_SRC),$@)
+	$(call DOWNLOAD,https://www.lua.org/ftp/$(LUA_SRC),$@)
 
 $(LUA_DIR): | $(LUA_SRC)
 	tar -zxf $(LUA_SRC)


### PR DESCRIPTION
www.lua.org has SSL enabled, so we should use it when downloading from their site. Some networks block unencrypted file downloads, so this may be a sticking point for users on those networks. Also, it's generally considered good practice to use SSL whenever available.