### PR TITLE
InstructionCounter: per-thread and per-process instruction counting

### DIFF
--- a/guest/common/include/s2e/instruction_counter.h
+++ b/guest/common/include/s2e/instruction_counter.h
@@ -1,0 +1,64 @@
+/// S2E Selective Symbolic Execution Platform
+///
+/// Copyright (c) 2023, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#ifndef S2E_INSTRUCTION_COUNTER_H
+#define S2E_INSTRUCTION_COUNTER_H
+
+#include <inttypes.h>
+#include <memory.h>
+#include <s2e/s2e.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum S2E_ICOUNT_COMMANDS { ICOUNT_RESET, ICOUNT_GET };
+
+struct S2E_ICOUNT_COMMAND {
+    enum S2E_ICOUNT_COMMANDS Command;
+    union {
+        uint64_t Count;
+    };
+} __attribute__((packed));
+
+static void s2e_icount_reset() {
+    struct S2E_ICOUNT_COMMAND cmd;
+    memset(&cmd, 0, sizeof(cmd));
+
+    cmd.Command = ICOUNT_RESET;
+    s2e_invoke_plugin("InstructionCounter", &cmd, sizeof(cmd));
+}
+
+static uint64_t s2e_icount_get() {
+    struct S2E_ICOUNT_COMMAND cmd;
+    memset(&cmd, 0, sizeof(cmd));
+
+    cmd.Command = ICOUNT_GET;
+    s2e_invoke_plugin("InstructionCounter", &cmd, sizeof(cmd));
+    return cmd.Count;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/guest/common/include/s2e/monitors/commands/decree.h
+++ b/guest/common/include/s2e/monitors/commands/decree.h
@@ -1,7 +1,7 @@
 /// S2E Selective Symbolic Execution Platform
 ///
-/// Copyright (c) 2017 Cyberhaven
-/// Copyright (c) 2017 Dependable Systems Lab, EPFL
+/// Copyright (c) 2015-2017, Cyberhaven
+/// Copyright (c) 2017, Dependable Systems Laboratory, EPFL
 ///
 /// Permission is hereby granted, free of charge, to any person obtaining a copy
 /// of this software and associated documentation files (the "Software"), to deal
@@ -20,9 +20,16 @@
 /// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
+///
 
 #ifndef S2E_DECREE_COMMANDS_H
 #define S2E_DECREE_COMMANDS_H
+
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
+#include <inttypes.h>
+#endif
 
 #include "linux.h"
 
@@ -30,7 +37,7 @@
 extern "C" {
 #endif
 
-#define S2E_DECREEMON_COMMAND_VERSION 0x201903202239ULL // date +%Y%m%d%H%M
+#define S2E_DECREEMON_COMMAND_VERSION 0x202301082207ULL // date +%Y%m%d%H%M
 
 enum S2E_DECREEMON_COMMANDS {
     DECREE_SEGFAULT,
@@ -53,6 +60,7 @@ enum S2E_DECREEMON_COMMANDS {
     DECREE_INIT,
     DECREE_KERNEL_PANIC,
     DECREE_MODULE_LOAD,
+    DECREE_TASK_SWITCH
 };
 
 struct S2E_DECREEMON_COMMAND_READ_DATA {
@@ -169,7 +177,6 @@ struct S2E_DECREEMON_VMA {
 struct S2E_DECREEMON_COMMAND_INIT {
     uint64_t page_offset;
     uint64_t start_kernel;
-    uint64_t task_struct_pid_offset;
 } __attribute__((packed));
 
 struct S2E_DECREEMON_COMMAND_KERNEL_PANIC {
@@ -180,7 +187,7 @@ struct S2E_DECREEMON_COMMAND_KERNEL_PANIC {
 struct S2E_DECREEMON_COMMAND {
     uint64_t version;
     enum S2E_DECREEMON_COMMANDS Command;
-    uint64_t currentPid;
+    struct S2E_LINUXMON_TASK CurrentTask;
     union {
         struct S2E_LINUXMON_COMMAND_PROCESS_LOAD ProcessLoad;
         struct S2E_LINUXMON_COMMAND_MODULE_LOAD ModuleLoad;
@@ -198,6 +205,7 @@ struct S2E_DECREEMON_COMMAND {
         struct S2E_DECREEMON_COMMAND_SET_CB_PARAMS CbParams;
         struct S2E_DECREEMON_COMMAND_INIT Init;
         struct S2E_DECREEMON_COMMAND_KERNEL_PANIC Panic;
+        struct S2E_LINUXMON_COMMAND_TASK_SWITCH TaskSwitch;
     };
     char currentName[32]; // not NULL terminated
 } __attribute__((packed));

--- a/guest/common/include/s2e/monitors/commands/linux.h
+++ b/guest/common/include/s2e/monitors/commands/linux.h
@@ -1,7 +1,6 @@
 /// S2E Selective Symbolic Execution Platform
 ///
-/// Copyright (c) 2017 Cyberhaven
-/// Copyright (c) 2017 Dependable Systems Lab, EPFL
+/// Copyright (c) 2017, Dependable Systems Laboratory, EPFL
 ///
 /// Permission is hereby granted, free of charge, to any person obtaining a copy
 /// of this software and associated documentation files (the "Software"), to deal
@@ -20,17 +19,16 @@
 /// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 /// SOFTWARE.
+///
 
 #ifndef S2E_LINUX_COMMANDS_H
 #define S2E_LINUX_COMMANDS_H
-
-#include <inttypes.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define S2E_LINUXMON_COMMAND_VERSION 0x201903212249ULL // date +%Y%m%d%H%M
+#define S2E_LINUXMON_COMMAND_VERSION 0x202301082207ULL // date +%Y%m%d%H%M
 
 enum S2E_LINUXMON_COMMANDS {
     LINUX_SEGFAULT,
@@ -38,11 +36,13 @@ enum S2E_LINUXMON_COMMANDS {
     LINUX_MODULE_LOAD,
     LINUX_TRAP,
     LINUX_PROCESS_EXIT,
+    LINUX_THREAD_EXIT,
     LINUX_INIT,
     LINUX_KERNEL_PANIC,
     LINUX_MEMORY_MAP,
     LINUX_MEMORY_UNMAP,
-    LINUX_MEMORY_PROTECT
+    LINUX_MEMORY_PROTECT,
+    LINUX_TASK_SWITCH
 };
 
 struct S2E_LINUXMON_COMMAND_MEMORY_MAP {
@@ -110,12 +110,19 @@ struct S2E_LINUXMON_COMMAND_PROCESS_EXIT {
     uint64_t code;
 } __attribute__((packed));
 
+struct S2E_LINUXMON_COMMAND_THREAD_EXIT {
+    uint64_t code;
+} __attribute__((packed));
+
+struct S2E_LINUXMON_TASK {
+    uint64_t task_struct;
+    uint64_t pid;
+    uint64_t tgid;
+} __attribute__((packed));
+
 struct S2E_LINUXMON_COMMAND_INIT {
     uint64_t page_offset;
     uint64_t start_kernel;
-    uint64_t current_task_address;
-    uint64_t task_struct_pid_offset;
-    uint64_t task_struct_tgid_offset;
 } __attribute__((packed));
 
 struct S2E_LINUXMON_COMMAND_KERNEL_PANIC {
@@ -123,21 +130,28 @@ struct S2E_LINUXMON_COMMAND_KERNEL_PANIC {
     uint64_t message_size;
 } __attribute__((packed));
 
+struct S2E_LINUXMON_COMMAND_TASK_SWITCH {
+    struct S2E_LINUXMON_TASK prev;
+    struct S2E_LINUXMON_TASK next;
+} __attribute__((packed));
+
 struct S2E_LINUXMON_COMMAND {
     uint64_t version;
     enum S2E_LINUXMON_COMMANDS Command;
-    uint64_t currentPid;
+    struct S2E_LINUXMON_TASK CurrentTask;
     union {
         struct S2E_LINUXMON_COMMAND_PROCESS_LOAD ProcessLoad;
         struct S2E_LINUXMON_COMMAND_MODULE_LOAD ModuleLoad;
         struct S2E_LINUXMON_COMMAND_SEG_FAULT SegFault;
         struct S2E_LINUXMON_COMMAND_TRAP Trap;
         struct S2E_LINUXMON_COMMAND_PROCESS_EXIT ProcessExit;
+        struct S2E_LINUXMON_COMMAND_THREAD_EXIT ThreadExit;
         struct S2E_LINUXMON_COMMAND_INIT Init;
         struct S2E_LINUXMON_COMMAND_KERNEL_PANIC Panic;
         struct S2E_LINUXMON_COMMAND_MEMORY_MAP MemMap;
         struct S2E_LINUXMON_COMMAND_MEMORY_UNMAP MemUnmap;
         struct S2E_LINUXMON_COMMAND_MEMORY_PROTECT MemProtect;
+        struct S2E_LINUXMON_COMMAND_TASK_SWITCH TaskSwitch;
     };
 } __attribute__((packed));
 

--- a/guest/common/include/s2e/monitors/linux.h
+++ b/guest/common/include/s2e/monitors/linux.h
@@ -31,6 +31,10 @@
 #define S2E_LINUX_MONITOR_H
 
 #include <memory.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <s2e/s2e.h>
 
 #ifdef __cplusplus
@@ -39,13 +43,18 @@ extern "C" {
 
 #include "commands/linux.h"
 
+static pid_t s2e_linux_gettid(void) {
+    return syscall(SYS_gettid);
+}
+
 static inline void s2e_linux_load_module(uint64_t pid, const struct S2E_LINUXMON_COMMAND_MODULE_LOAD *m) {
     struct S2E_LINUXMON_COMMAND cmd;
     memset(&cmd, 0, sizeof(cmd));
 
     cmd.version = S2E_LINUXMON_COMMAND_VERSION;
     cmd.Command = LINUX_MODULE_LOAD;
-    cmd.currentPid = pid;
+    cmd.CurrentTask.tgid = getpid();
+    cmd.CurrentTask.pid = s2e_linux_gettid();
     cmd.ModuleLoad = *m;
     __s2e_touch_string((char *) cmd.ModuleLoad.module_path);
 

--- a/guest/common/include/s2e/monitors/support/process_execution_detector.h
+++ b/guest/common/include/s2e/monitors/support/process_execution_detector.h
@@ -1,0 +1,74 @@
+/// S2E Selective Symbolic Execution Platform
+///
+/// Copyright (c) 2023, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#ifndef S2E_PROCEXECDETECTOR_H
+#define S2E_PROCEXECDETECTOR_H
+
+#include <inttypes.h>
+#include <memory.h>
+
+#if !defined(LIBS2E_PLUGINS)
+#include <s2e/s2e.h>
+#endif
+
+#ifdef __cplusplus
+namespace s2e {
+namespace plugins {
+extern "C" {
+#endif
+
+enum S2E_PROCEXECDETECTOR_COMMANDS { PROCEXEC_ENABLE_PID, PROCEXEC_DISABLE_PID };
+
+struct S2E_PROCEXECDETECTOR_COMMAND {
+    enum S2E_PROCEXECDETECTOR_COMMANDS Command;
+    union {
+        uint64_t Pid;
+    };
+} __attribute__((packed));
+
+#if !defined(LIBS2E_PLUGINS)
+static void s2e_procexec_enable_pid(uint64_t pid) {
+    struct S2E_PROCEXECDETECTOR_COMMAND cmd;
+    memset(&cmd, 0, sizeof(cmd));
+
+    cmd.Command = PROCEXEC_ENABLE_PID;
+    cmd.Pid = pid;
+    s2e_invoke_plugin("ProcessExecutionDetector", &cmd, sizeof(cmd));
+}
+
+static void s2e_procexec_disable_pid(uint64_t pid) {
+    struct S2E_PROCEXECDETECTOR_COMMAND cmd;
+    memset(&cmd, 0, sizeof(cmd));
+
+    cmd.Command = PROCEXEC_DISABLE_PID;
+    cmd.Pid = pid;
+    s2e_invoke_plugin("ProcessExecutionDetector", &cmd, sizeof(cmd));
+}
+#endif
+
+#ifdef __cplusplus
+}
+}
+}
+#endif
+
+#endif

--- a/guest/common/include/s2e/monitors/support/thread_execution_detector.h
+++ b/guest/common/include/s2e/monitors/support/thread_execution_detector.h
@@ -1,0 +1,90 @@
+/// S2E Selective Symbolic Execution Platform
+///
+/// Copyright (c) 2023, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#ifndef S2E_THREADEXECDETECTOR_H
+#define S2E_THREADEXECDETECTOR_H
+
+#include <inttypes.h>
+#include <memory.h>
+
+#if !defined(LIBS2E_PLUGINS)
+#include <s2e/s2e.h>
+#endif
+
+#ifdef __cplusplus
+namespace s2e {
+namespace plugins {
+extern "C" {
+#endif
+
+enum S2E_THREADEXECDETECTOR_COMMANDS {
+    THREADEXEC_ENABLE_KERNEL_TRACKING,
+    THREADEXEC_DISABLE_KERNEL_TRACKING,
+    THREADEXEC_ENABLE_CURRENT,
+    THREADEXEC_DISABLE_CURRENT
+};
+
+struct S2E_THREADEXECDETECTOR_COMMAND {
+    enum S2E_THREADEXECDETECTOR_COMMANDS Command;
+} __attribute__((packed));
+
+#if !defined(LIBS2E_PLUGINS)
+static void s2e_thread_exec_enable_kernel_tracking() {
+    struct S2E_THREADEXECDETECTOR_COMMAND cmd;
+    memset(&cmd, 0, sizeof(cmd));
+
+    cmd.Command = THREADEXEC_ENABLE_KERNEL_TRACKING;
+    s2e_invoke_plugin("ThreadExecutionDetector", &cmd, sizeof(cmd));
+}
+
+static void s2e_thread_exec_disable_kernel_tracking() {
+    struct S2E_THREADEXECDETECTOR_COMMAND cmd;
+    memset(&cmd, 0, sizeof(cmd));
+
+    cmd.Command = THREADEXEC_DISABLE_KERNEL_TRACKING;
+    s2e_invoke_plugin("ThreadExecutionDetector", &cmd, sizeof(cmd));
+}
+
+static void s2e_thread_exec_enable_current() {
+    struct S2E_THREADEXECDETECTOR_COMMAND cmd;
+    memset(&cmd, 0, sizeof(cmd));
+
+    cmd.Command = THREADEXEC_ENABLE_CURRENT;
+    s2e_invoke_plugin("ThreadExecutionDetector", &cmd, sizeof(cmd));
+}
+
+static void s2e_thread_exec_disable_current() {
+    struct S2E_THREADEXECDETECTOR_COMMAND cmd;
+    memset(&cmd, 0, sizeof(cmd));
+
+    cmd.Command = THREADEXEC_DISABLE_CURRENT;
+    s2e_invoke_plugin("ThreadExecutionDetector", &cmd, sizeof(cmd));
+}
+#endif
+
+#ifdef __cplusplus
+}
+}
+}
+#endif
+
+#endif

--- a/guest/linux/cgccmd/cgccmd.c
+++ b/guest/linux/cgccmd/cgccmd.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 typedef int (*cmd_handler_t)(const char **args);
@@ -39,11 +40,16 @@ typedef struct _cmd_t {
     char *description;
 } cmd_t;
 
+static pid_t s2e_decree_gettid(void) {
+    return syscall(SYS_gettid);
+}
+
 static int handler_concolic(const char **args) {
     struct S2E_DECREEMON_COMMAND cmd = {0};
 
     cmd.version = S2E_DECREEMON_COMMAND_VERSION;
-    cmd.currentPid = getpid();
+    cmd.CurrentTask.tgid = getpid();
+    cmd.CurrentTask.pid = s2e_decree_gettid();
     strncpy(cmd.currentName, "cgccmd", sizeof(cmd.currentName));
 
     int enable = !strcmp(args[0], "on");

--- a/libs2ecore/include/s2e/S2EExecutionState.h
+++ b/libs2ecore/include/s2e/S2EExecutionState.h
@@ -209,6 +209,14 @@ public:
         return (*it).second;
     }
 
+    template <typename T> T *getPluginState(Plugin *plugin) const {
+        auto it = m_PluginState.find(plugin);
+        if (it == m_PluginState.end()) {
+            return nullptr;
+        }
+        return dynamic_cast<T *>((*it).second);
+    }
+
     /** Returns true if this is the active state */
     inline bool isActive() const {
         return m_active;

--- a/libs2eplugins/src/CMakeLists.txt
+++ b/libs2eplugins/src/CMakeLists.txt
@@ -165,6 +165,7 @@ set(WERROR_FLAGS "-Werror -Wno-zero-length-array -Wno-c99-extensions          \
                   -Wno-zero-length-array")
 
 set(COMMON_FLAGS "-D__STDC_FORMAT_MACROS -D_GNU_SOURCE -DNEED_CPU_H  -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DTARGET_PHYS_ADDR_BITS=64")
+set(COMMON_FLAGS "${COMMON_FLAGS} -DLIBS2E_PLUGINS")
 set(COMMON_FLAGS "${COMMON_FLAGS} -Wall -fPIC -fno-strict-aliasing -fexceptions -std=c++17")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WERROR_FLAGS} ${COMMON_FLAGS}")

--- a/libs2eplugins/src/CMakeLists.txt
+++ b/libs2eplugins/src/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(
     # Guest support
     s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
     s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
+    s2e/Plugins/OSMonitors/Support/ThreadExecutionDetector.cpp
     s2e/Plugins/OSMonitors/Support/ModuleMap.cpp
     s2e/Plugins/OSMonitors/Support/MemoryMap.cpp
     s2e/Plugins/OSMonitors/Support/MemUtils.cpp

--- a/libs2eplugins/src/CMakeLists.txt
+++ b/libs2eplugins/src/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(
     s2e/Plugins/OSMonitors/Support/MemoryMap.cpp
     s2e/Plugins/OSMonitors/Support/MemUtils.cpp
     s2e/Plugins/OSMonitors/Support/GuestCodeHooking.cpp
+    s2e/Plugins/OSMonitors/Support/ITracker.cpp
     s2e/Plugins/OSMonitors/OSMonitor.cpp
 
     # CGC support

--- a/libs2eplugins/src/s2e/Plugins/Analyzers/AddressTracker.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Analyzers/AddressTracker.cpp
@@ -144,7 +144,7 @@ void AddressTracker::onMonitorLoad(S2EExecutionState *state) {
 }
 
 void AddressTracker::onModuleLoad(S2EExecutionState *state, const ModuleDescriptor &module) {
-    if (!m_process->isTracked(state, module.Pid)) {
+    if (!m_process->isTrackedPid(state, module.Pid)) {
         return;
     }
 

--- a/libs2eplugins/src/s2e/Plugins/Analyzers/CFIChecker.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Analyzers/CFIChecker.cpp
@@ -439,7 +439,7 @@ void CFIChecker::onProcessOrThreadSwitch(S2EExecutionState *state) {
 
     plgState->setPidTid(pid, tid);
 
-    auto isTracked = m_process->isTracked(state, pid);
+    auto isTracked = m_process->isTrackedPid(state, pid);
     g_invokeCallRetInstrumentation = isTracked ? (void *) 1 : nullptr;
 }
 

--- a/libs2eplugins/src/s2e/Plugins/ExecutionMonitors/StackMonitor.cpp
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionMonitors/StackMonitor.cpp
@@ -323,7 +323,7 @@ void StackMonitor::update(S2EExecutionState *state, uint64_t sp, uint64_t pc, bo
 }
 
 void StackMonitor::onThreadExit(S2EExecutionState *state, const ThreadDescriptor &thread) {
-    if (!m_processDetector->isTracked(state, thread.Pid)) {
+    if (!m_processDetector->isTrackedPid(state, thread.Pid)) {
         return;
     }
 
@@ -332,7 +332,7 @@ void StackMonitor::onThreadExit(S2EExecutionState *state, const ThreadDescriptor
 }
 
 void StackMonitor::onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid, uint64_t returnCode) {
-    if (!m_processDetector->isTracked(state, pid)) {
+    if (!m_processDetector->isTrackedPid(state, pid)) {
         return;
     }
 

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/ExecutionTracer.cpp
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/ExecutionTracer.cpp
@@ -151,6 +151,13 @@ uint32_t ExecutionTracer::writeData(S2EExecutionState *state, const void *data, 
         header.set_tid(0);
     }
 
+    return writeData(state, header, data, size, type);
+}
+
+uint32_t ExecutionTracer::writeData(S2EExecutionState *state, s2e_trace::PbTraceItemHeader &header, const void *data,
+                                    unsigned size, uint32_t type /* s2e_trace::PbTraceItemHeaderType */) {
+    assert(m_logFile);
+
     // We must take the guid instead of the id, because duplicate ids
     // across multiple traces will confuse the execution trace reader.
     header.set_state_id(state->getGuid());

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/ExecutionTracer.h
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/ExecutionTracer.h
@@ -75,6 +75,16 @@ public:
     ~ExecutionTracer();
     void initialize();
 
+    template <typename T>
+    uint32_t writeData(S2EExecutionState *state, s2e_trace::PbTraceItemHeader &header, const T &item, uint32_t type) {
+        std::string data;
+        if (!item.AppendToString(&data)) {
+            getWarningsStream(state) << "Could not serialize protobuf data\n";
+            exit(-1);
+        }
+        return writeData(state, header, data.c_str(), data.size(), type);
+    }
+
     template <typename T> uint32_t writeData(S2EExecutionState *state, const T &item, uint32_t type) {
         std::string data;
         if (!item.AppendToString(&data)) {
@@ -83,6 +93,9 @@ public:
         }
         return writeData(state, data.c_str(), data.size(), type);
     }
+
+    uint32_t writeData(S2EExecutionState *state, s2e_trace::PbTraceItemHeader &header, const void *data, unsigned size,
+                       uint32_t type /* s2e_trace::PbTraceItemHeaderType */);
 
     uint32_t writeData(S2EExecutionState *state, const void *data, unsigned size,
                        uint32_t type /* s2e_trace::PbTraceItemHeaderType */);

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/InstructionCounter.cpp
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/InstructionCounter.cpp
@@ -31,18 +31,33 @@
 
 #include <TraceEntries.pb.h>
 
+// TODO: deduplicate with UserSpaceTracer
+namespace std {
+template <typename T1, typename T2> struct hash<std::pair<T1, T2>> {
+    std::size_t operator()(std::pair<T1, T2> const &p) const {
+        return p.first ^ p.second;
+    }
+};
+} // namespace std
+
 namespace s2e {
 namespace plugins {
 
 S2E_DEFINE_PLUGIN(InstructionCounter, "Instruction counter plugin", "InstructionCounter", "ExecutionTracer",
-                  "ProcessExecutionDetector", "ModuleMap");
+                  "ProcessExecutionDetector", "ModuleMap", "OSMonitor");
 
 namespace {
 class InstructionCounterState : public PluginState {
+public:
+    using PidTid = std::pair<uint64_t, uint64_t>;
+    using Counts = std::unordered_map<PidTid, uint64_t /* count */>;
+
 private:
-    uint64_t m_count = 0;
     bool m_enabled = false;
-    void *m_cachedTb = nullptr;
+
+    uint64_t m_count = 0;
+    PidTid m_current = PidTid(-1, -1);
+    Counts m_counts;
 
 public:
     InstructionCounterState(S2EExecutionState *s, Plugin *p){
@@ -57,12 +72,27 @@ public:
         return new InstructionCounterState(s, p);
     }
 
+    inline void updatePidTid(uint64_t pid, uint64_t tid) {
+        auto pt = PidTid(pid, tid);
+        if (m_current != pt) {
+            m_counts[m_current] = m_count;
+            m_count = m_counts[pt];
+            m_current = pt;
+        }
+    }
+
+    inline void flush() {
+        m_counts[m_current] = m_count;
+        m_count = 0;
+        m_current = PidTid(-1, -1);
+    }
+
     inline void inc() {
         m_count++;
     }
 
-    inline uint64_t get() const {
-        return m_count;
+    inline Counts &get() {
+        return m_counts;
     }
 
     inline void enable(bool v) {
@@ -72,47 +102,55 @@ public:
     inline bool enabled() const {
         return m_enabled;
     }
-
-    inline void *getCachedTb() const {
-        return m_cachedTb;
-    }
-
-    inline void setCachedTb(void *tb) {
-        m_cachedTb = tb;
-    }
 };
 } // namespace
 
 void InstructionCounter::initialize() {
     m_tracer = s2e()->getPlugin<ExecutionTracer>();
     m_detector = s2e()->getPlugin<ProcessExecutionDetector>();
+    m_monitor = static_cast<OSMonitor *>(s2e()->getPlugin("OSMonitor"));
 
     m_modules.initialize(s2e(), getConfigKey());
 
-    s2e()->getCorePlugin()->onInitializationComplete.connect(
-        sigc::mem_fun(*this, &InstructionCounter::onInitializationComplete));
-    s2e()->getCorePlugin()->onTranslateBlockStart.connect(
-        sigc::mem_fun(*this, &InstructionCounter::onTranslateBlockStart));
     s2e()->getCorePlugin()->onStateKill.connect(sigc::mem_fun(*this, &InstructionCounter::onStateKill));
+
+    m_monitor->onProcessUnload.connect(sigc::mem_fun(*this, &InstructionCounter::onProcessUnload));
+    m_monitor->onThreadExit.connect(sigc::mem_fun(*this, &InstructionCounter::onThreadExit));
+    m_monitor->onMonitorLoad.connect(sigc::mem_fun(*this, &InstructionCounter::onMonitorLoad));
 }
 
-void InstructionCounter::onInitializationComplete(S2EExecutionState *state) {
-    DECLARE_PLUGINSTATE(InstructionCounterState, state);
-    plgState->enable(true);
+void InstructionCounter::onMonitorLoad(S2EExecutionState *state) {
+    s2e()->getCorePlugin()->onTranslateBlockStart.connect(
+        sigc::mem_fun(*this, &InstructionCounter::onTranslateBlockStart));
+
+    s2e()->getCorePlugin()->onTranslateInstructionStart.connect(
+        sigc::mem_fun(*this, &InstructionCounter::onTranslateInstructionStart));
+
+    // Make sure we don't miss any TBs.
+    se_tb_safe_flush();
 }
 
 void InstructionCounter::onTranslateBlockStart(ExecutionSignal *signal, S2EExecutionState *state, TranslationBlock *tb,
                                                uint64_t pc) {
-    if (!m_modules.isModuleTraced(state, pc)) {
-        m_tbConnection.disconnect();
+    signal->connect(sigc::mem_fun(*this, &InstructionCounter::onTbExecuteStart));
+}
+
+void InstructionCounter::onTbExecuteStart(S2EExecutionState *state, uint64_t pc) {
+    DECLARE_PLUGINSTATE(InstructionCounterState, state);
+
+    if (!m_detector->isTracked(state)) {
+        plgState->enable(false);
         return;
     }
 
-    if (!m_tbConnection.connected()) {
-        CorePlugin *plg = s2e()->getCorePlugin();
-        m_tbConnection = plg->onTranslateInstructionStart.connect(
-            sigc::mem_fun(*this, &InstructionCounter::onTranslateInstructionStart));
-    }
+    auto pid = m_monitor->getPid(state);
+    auto tid = m_monitor->getTid(state);
+
+    plgState->updatePidTid(pid, tid);
+
+    // Per-module filtering.
+    auto isTraced = m_modules.isModuleTraced(state, pc);
+    plgState->enable(isTraced);
 }
 
 void InstructionCounter::onTranslateInstructionStart(ExecutionSignal *signal, S2EExecutionState *state,
@@ -124,30 +162,81 @@ void InstructionCounter::onTranslateInstructionStart(ExecutionSignal *signal, S2
 void InstructionCounter::onInstruction(S2EExecutionState *state, uint64_t pc) {
     // Get the plugin state for the current path
     DECLARE_PLUGINSTATE(InstructionCounterState, state);
-    if (!plgState->enabled()) {
-        return;
-    }
-
-    // This is an optimization to avoid expensive module lookups
-    if (plgState->getCachedTb() == state->getTb()) {
+    if (plgState->enabled()) {
         plgState->inc();
-        return;
-    }
-
-    if (m_modules.isModuleTraced(state, pc)) {
-        plgState->inc();
-        plgState->setCachedTb(state->getTb());
     }
 }
 
-void InstructionCounter::onStateKill(S2EExecutionState *state) {
-    // Get the plugin state for the current path
-    DECLARE_PLUGINSTATE(InstructionCounterState, state);
+void InstructionCounter::writeData(S2EExecutionState *state, uint64_t pid, uint64_t tid, uint64_t count) {
+    if (count == 0) {
+        return;
+    }
 
-    // Flush the counter
+    if (pid == -1 && tid == -1) {
+        return;
+    }
+
+    s2e_trace::PbTraceItemHeader header;
+
+    header.set_address_space(-1);
+    header.set_pc(-1);
+
+    header.set_pid(pid);
+    header.set_tid(tid);
+
     s2e_trace::PbTraceInstructionCount item;
-    item.set_count(plgState->get());
-    m_tracer->writeData(state, item, s2e_trace::TRACE_ICOUNT);
+    item.set_count(count);
+    m_tracer->writeData(state, header, item, s2e_trace::TRACE_ICOUNT);
+}
+
+void InstructionCounter::onStateKill(S2EExecutionState *state) {
+    DECLARE_PLUGINSTATE(InstructionCounterState, state);
+    plgState->flush();
+
+    for (auto kv : plgState->get()) {
+        auto pid = kv.first.first;
+        auto tid = kv.first.second;
+        writeData(state, pid, tid, kv.second);
+    }
+}
+
+void InstructionCounter::onThreadExit(S2EExecutionState *state, const ThreadDescriptor &thread) {
+    DECLARE_PLUGINSTATE(InstructionCounterState, state);
+    plgState->flush();
+
+    auto &counts = plgState->get();
+    for (auto kv : counts) {
+        auto pid = kv.first.first;
+        auto tid = kv.first.second;
+
+        if (pid == thread.Pid && tid == thread.Tid) {
+            writeData(state, pid, tid, kv.second);
+            counts.erase(std::make_pair(pid, tid));
+        }
+    }
+}
+
+void InstructionCounter::onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t ppid,
+                                         uint64_t returnCode) {
+    DECLARE_PLUGINSTATE(InstructionCounterState, state);
+    plgState->flush();
+
+    std::vector<InstructionCounterState::PidTid> toErase;
+
+    auto &counts = plgState->get();
+    for (auto kv : counts) {
+        auto pid = kv.first.first;
+        auto tid = kv.first.second;
+
+        if (pid == ppid) {
+            writeData(state, pid, tid, kv.second);
+            toErase.push_back(std::make_pair(pid, tid));
+        }
+    }
+
+    for (auto &pt : toErase) {
+        counts.erase(pt);
+    }
 }
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/InstructionCounter.h
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/InstructionCounter.h
@@ -28,6 +28,8 @@
 #include <s2e/S2EExecutionState.h>
 #include <unordered_set>
 
+#include <s2e/Plugins/OSMonitors/OSMonitor.h>
+
 #include "ExecutionTracer.h"
 #include "ModuleTracing.h"
 
@@ -42,10 +44,9 @@ class InstructionCounter : public Plugin {
 private:
     ExecutionTracer *m_tracer;
     ProcessExecutionDetector *m_detector;
+    OSMonitor *m_monitor;
 
     ModuleTracing m_modules;
-
-    sigc::connection m_tbConnection;
 
 public:
     InstructionCounter(S2E *s2e) : Plugin(s2e) {
@@ -54,14 +55,20 @@ public:
     void initialize();
 
 private:
-    void onInitializationComplete(S2EExecutionState *state);
+    void writeData(S2EExecutionState *state, uint64_t pid, uint64_t tid, uint64_t count);
+
+    void onMonitorLoad(S2EExecutionState *state);
     void onStateKill(S2EExecutionState *state);
     void onTranslateBlockStart(ExecutionSignal *signal, S2EExecutionState *state, TranslationBlock *tb, uint64_t pc);
+    void onTbExecuteStart(S2EExecutionState *state, uint64_t pc);
 
     void onTranslateInstructionStart(ExecutionSignal *signal, S2EExecutionState *state, TranslationBlock *tb,
                                      uint64_t pc);
 
     void onInstruction(S2EExecutionState *state, uint64_t pc);
+
+    void onThreadExit(S2EExecutionState *state, const ThreadDescriptor &thread);
+    void onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid, uint64_t returnCode);
 };
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/InstructionCounter.h
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/InstructionCounter.h
@@ -29,9 +29,9 @@
 #include <unordered_set>
 
 #include <s2e/Plugins/OSMonitors/OSMonitor.h>
+#include <s2e/Plugins/OSMonitors/Support/ITracker.h>
 
 #include "ExecutionTracer.h"
-#include "ModuleTracing.h"
 
 namespace s2e {
 namespace plugins {
@@ -51,11 +51,9 @@ class ModuleMap;
 class InstructionCounter : public Plugin, public IPluginInvoker {
     S2E_PLUGIN
 private:
-    ExecutionTracer *m_tracer;
-    ProcessExecutionDetector *m_detector;
-    OSMonitor *m_monitor;
-
-    ModuleTracing m_modules;
+    ExecutionTracer *m_tracer = nullptr;
+    ITracker *m_tracker = nullptr;
+    OSMonitor *m_monitor = nullptr;
 
 public:
     InstructionCounter(S2E *s2e) : Plugin(s2e) {
@@ -64,6 +62,7 @@ public:
     void initialize();
 
 private:
+    void onConfigChange(S2EExecutionState *state);
     void writeData(S2EExecutionState *state, uint64_t pid, uint64_t tid, uint64_t count);
 
     void onMonitorLoad(S2EExecutionState *state);
@@ -78,6 +77,8 @@ private:
 
     void onThreadExit(S2EExecutionState *state, const ThreadDescriptor &thread);
     void onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid, uint64_t returnCode);
+
+    void onProcessOrThreadSwitch(S2EExecutionState *state);
 
     void handleOpcodeInvocation(S2EExecutionState *state, uint64_t guestDataPtr, uint64_t guestDataSize);
 };

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/InstructionCounter.h
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/InstructionCounter.h
@@ -36,10 +36,19 @@
 namespace s2e {
 namespace plugins {
 
+enum S2E_ICOUNT_COMMANDS { ICOUNT_RESET, ICOUNT_GET };
+
+struct S2E_ICOUNT_COMMAND {
+    enum S2E_ICOUNT_COMMANDS Command;
+    union {
+        uint64_t Count;
+    };
+} __attribute__((packed));
+
 class ProcessExecutionDetector;
 class ModuleMap;
 
-class InstructionCounter : public Plugin {
+class InstructionCounter : public Plugin, public IPluginInvoker {
     S2E_PLUGIN
 private:
     ExecutionTracer *m_tracer;
@@ -69,6 +78,8 @@ private:
 
     void onThreadExit(S2EExecutionState *state, const ThreadDescriptor &thread);
     void onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid, uint64_t returnCode);
+
+    void handleOpcodeInvocation(S2EExecutionState *state, uint64_t guestDataPtr, uint64_t guestDataSize);
 };
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/MemoryTracer.h
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/MemoryTracer.h
@@ -25,13 +25,12 @@
 #define S2E_PLUGINS_MEMTRACER_H
 
 #include <s2e/Plugin.h>
+#include <s2e/Plugins/OSMonitors/Support/ITracker.h>
 #include <s2e/Plugins/OSMonitors/Support/ModuleMap.h>
-#include <s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.h>
 
 #include <string>
 
 #include "ExecutionTracer.h"
-#include "ModuleTracing.h"
 
 namespace s2e {
 namespace plugins {
@@ -59,9 +58,8 @@ private:
     bool m_debugObjectStates;
 
     ExecutionTracer *m_tracer;
-    ProcessExecutionDetector *m_detector;
 
-    ModuleTracing m_modules;
+    ITracker *m_tracker;
 
     void onTlbMiss(S2EExecutionState *state, uint64_t addr, bool is_write);
     void onPageFault(S2EExecutionState *state, uint64_t addr, bool is_write);

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/ModuleTracer.cpp
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/ModuleTracer.cpp
@@ -51,9 +51,13 @@ void ModuleTracer::initialize() {
 
     OSMonitor *monitor = static_cast<OSMonitor *>(s2e()->getPlugin("OSMonitor"));
 
-    monitor->onModuleLoad.connect(sigc::mem_fun(*this, &ModuleTracer::moduleLoadListener));
-    monitor->onModuleUnload.connect(sigc::mem_fun(*this, &ModuleTracer::moduleUnloadListener));
-    monitor->onProcessUnload.connect(sigc::mem_fun(*this, &ModuleTracer::processUnloadListener));
+    // These module events must come first/last in the trace for it to be parsed properly.
+    monitor->onModuleLoad.connect(sigc::mem_fun(*this, &ModuleTracer::moduleLoadListener),
+                                  sigc::signal_base::HIGHEST_PRIORITY);
+    monitor->onModuleUnload.connect(sigc::mem_fun(*this, &ModuleTracer::moduleUnloadListener),
+                                    sigc::signal_base::LOWEST_PRIORITY);
+    monitor->onProcessUnload.connect(sigc::mem_fun(*this, &ModuleTracer::processUnloadListener),
+                                     sigc::signal_base::LOWEST_PRIORITY);
 }
 
 bool ModuleTracer::initSection(TracerConfigEntry *cfgEntry, const std::string &cfgKey, const std::string &entryId) {

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/TranslationBlockTracer.h
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/TranslationBlockTracer.h
@@ -28,10 +28,9 @@
 #include <s2e/Plugin.h>
 #include <s2e/S2EExecutionState.h>
 
+#include <s2e/Plugins/OSMonitors/Support/ITracker.h>
 #include <s2e/Plugins/OSMonitors/Support/ModuleMap.h>
-#include <s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.h>
 #include "ExecutionTracer.h"
-#include "ModuleTracing.h"
 
 namespace s2e {
 namespace plugins {
@@ -50,13 +49,11 @@ public:
     bool setProperty(S2EExecutionState *state, const std::string &name, const std::string &value);
 
 private:
-    ExecutionTracer *m_tracer;
-    ProcessExecutionDetector *m_detector;
+    ExecutionTracer *m_tracer = nullptr;
+    ITracker *m_tracker = nullptr;
 
     bool m_traceTbStart;
     bool m_traceTbEnd;
-
-    ModuleTracing m_modules;
 
     bool isModuleTraced(S2EExecutionState *state, uint64_t pc);
 

--- a/libs2eplugins/src/s2e/Plugins/ExecutionTracers/UserSpaceTracer.cpp
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionTracers/UserSpaceTracer.cpp
@@ -29,18 +29,11 @@
 #include <s2e/Plugins/ExecutionTracers/ExecutionTracer.h>
 #include <s2e/Plugins/ExecutionTracers/MemoryTracer.h>
 #include <s2e/Plugins/ExecutionTracers/TranslationBlockTracer.h>
+#include <s2e/Plugins/OSMonitors/Support/PidTid.h>
 #include <s2e/Plugins/OSMonitors/Windows/WindowsMonitor.h>
 
 #include <TraceEntries.pb.h>
 #include "UserSpaceTracer.h"
-
-namespace std {
-template <typename T1, typename T2> struct hash<std::pair<T1, T2>> {
-    std::size_t operator()(std::pair<T1, T2> const &p) const {
-        return p.first ^ p.second;
-    }
-};
-} // namespace std
 
 namespace s2e {
 namespace plugins {
@@ -59,7 +52,6 @@ public:
     using TraceInfoPtr = std::shared_ptr<TraceInfo>;
 
     using Pid = uint64_t;
-    using PidTid = std::pair<uint64_t, uint64_t>;
     using PidTids = std::unordered_map<PidTid, TraceInfoPtr>;
     using Pids = llvm::DenseSet<Pid>;
 

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Linux/BaseLinuxMonitor.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Linux/BaseLinuxMonitor.h
@@ -57,6 +57,30 @@ static const uint64_t STACK_SIZE = 16 * 1024 * 1024;
 
 } // namespace linux_common
 
+class BaseLinuxMonitorState : public PluginState {
+private:
+    uint64_t mTgid = -1;
+    uint64_t mPid = -1;
+
+public:
+    BaseLinuxMonitorState(){};
+    virtual ~BaseLinuxMonitorState(){};
+    virtual PluginState *clone() const = 0;
+
+    inline uint64_t getTgid() const {
+        return mTgid;
+    }
+
+    inline uint64_t getPid() const {
+        return mPid;
+    }
+
+    inline void setPidTgid(uint64_t pid, uint64_t tgid) {
+        mPid = pid;
+        mTgid = tgid;
+    }
+};
+
 ///
 /// \brief Abstract base plugin for X86 Linux monitors, including the Linux and
 /// CGC monitors
@@ -72,9 +96,6 @@ protected:
     /// Start address of the Linux kernel
     uint64_t m_kernelStartAddress;
 
-    /// Offset of the process identifier in the \c task_struct struct (see include/linux/sched.h)
-    uint64_t m_taskStructPidOffset;
-
     /// Terminate if a segment fault occurs
     bool m_terminateOnSegfault;
 
@@ -87,6 +108,9 @@ protected:
 
     void handleModuleLoad(S2EExecutionState *state, uint64_t pid, const S2E_LINUXMON_COMMAND_MODULE_LOAD &modLoad);
     void handleProcessLoad(S2EExecutionState *state, uint64_t pid, const S2E_LINUXMON_COMMAND_PROCESS_LOAD &procLoad);
+
+    void handleTaskSwitch(S2EExecutionState *state, const S2E_LINUXMON_TASK &CurrentTask,
+                          const S2E_LINUXMON_COMMAND_TASK_SWITCH &TaskSwitch);
 
     template <typename T>
     bool loadSections(S2EExecutionState *state, uint64_t phdr, uint64_t phdr_size,
@@ -182,6 +206,12 @@ public:
         state->mem()->readString(message, str, messageSize);
         g_s2e->getExecutor()->terminateState(*state, str);
     }
+
+    // Get the current process identifier
+    virtual uint64_t getPid(S2EExecutionState *state);
+
+    /// Get the current thread identifier
+    virtual uint64_t getTid(S2EExecutionState *state);
 };
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Linux/DecreeMonitor.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Linux/DecreeMonitor.h
@@ -229,9 +229,6 @@ public:
 
     bool getFaultAddress(S2EExecutionState *state, uint64_t siginfo_ptr, uint64_t *address);
 
-    virtual uint64_t getPid(S2EExecutionState *state);
-    virtual uint64_t getTid(S2EExecutionState *state);
-
     void getPreFeedData(S2EExecutionState *state, uint64_t pid, uint64_t count, std::vector<uint8_t> &data);
     void getRandomData(S2EExecutionState *state, uint64_t count, std::vector<uint8_t> &data);
     klee::ref<klee::Expr> makeSymbolicRead(S2EExecutionState *state, uint64_t pid, uint64_t fd, uint64_t buf,
@@ -245,6 +242,8 @@ public:
     static bool isWriteFd(uint32_t fd);
 
 private:
+    void onInitializationComplete(S2EExecutionState *state);
+
     target_ulong getTaskStructPtr(S2EExecutionState *state);
 
     uint64_t getMaxValue(S2EExecutionState *state, klee::ref<klee::Expr> value);
@@ -273,6 +272,7 @@ private:
                                const S2E_DECREEMON_COMMAND_UPDATE_MEMORY_MAP &d);
     void handleSetParams(S2EExecutionState *state, uint64_t pid, S2E_DECREEMON_COMMAND_SET_CB_PARAMS &d);
     void handleInit(S2EExecutionState *state, const S2E_DECREEMON_COMMAND_INIT &d);
+    void handleTaskSwitch(S2EExecutionState *state, const S2E_DECREEMON_COMMAND &cmd);
 };
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Linux/LinuxMonitor.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Linux/LinuxMonitor.h
@@ -70,14 +70,10 @@ public:
     void initialize();
 
 private:
-    /// Address of the \c current_task object in the Linux kernel (see arch/x86/kernel/cpu/common.c)
-    uint64_t m_currentTaskAddr;
-
-    /// Offset of the thread group identifier in the \c task_struct struct (see include/linux/sched.h)
-    uint64_t m_taskStructTgidOffset;
-
     /// Terminate if a trap (e.g. divide by zero) occurs
     bool m_terminateOnTrap;
+
+    void onInitializationComplete(S2EExecutionState *state);
 
     //
     // Handle the various commands emitted by the kernel
@@ -86,11 +82,13 @@ private:
 
     void handleSegfault(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
     void handleProcessExit(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
+    void handleThreadExit(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
     void handleTrap(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
     void handleInit(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
     void handleMemMap(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
     void handleMemUnmap(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
     void handleMemProtect(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
+    void handleTaskSwitch(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd);
 
 public:
     /// Emitted when a trap occurs in the kernel (e.g. divide by zero, etc.)
@@ -109,12 +107,6 @@ public:
     sigc::signal<void, S2EExecutionState *, uint64_t /* pid */, uint64_t /* start */, uint64_t /* size */,
                  uint64_t /* prot */>
         onMemoryProtect;
-
-    // Get the current process identifier
-    virtual uint64_t getPid(S2EExecutionState *state);
-
-    /// Get the current thread identifier
-    virtual uint64_t getTid(S2EExecutionState *state);
 };
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/OSMonitor.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/OSMonitor.h
@@ -65,6 +65,8 @@ public:
     sigc::signal<void, S2EExecutionState *, const ThreadDescriptor &> onThreadCreate;
     sigc::signal<void, S2EExecutionState *, const ThreadDescriptor &> onThreadExit;
 
+    sigc::signal<void, S2EExecutionState *> onProcessOrThreadSwitch;
+
     ///
     /// \brief Triggered when the OSMonitor plugin is ready for use.
     ///

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ITracker.cpp
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ITracker.cpp
@@ -1,0 +1,61 @@
+
+///
+/// Copyright (C) 2023, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#include <s2e/ConfigFile.h>
+#include <s2e/Plugin.h>
+#include <s2e/S2E.h>
+#include <s2e/S2EExecutionState.h>
+
+#include "ITracker.h"
+
+namespace s2e {
+namespace plugins {
+
+bool ITracker::isTracked(S2EExecutionState *state) {
+    return isTrackedPc(state, state->regs()->getPc());
+}
+
+ITracker *ITracker::getTracker(S2E *s2e, Plugin *plugin) {
+    auto filterPluginName = s2e->getConfig()->getString(plugin->getConfigKey() + ".filterPlugin");
+    if (filterPluginName.size() == 0) {
+        s2e->getWarningsStream() << "could not find .filterPlugin config key\n";
+        return nullptr;
+    }
+
+    auto filterPlugin = s2e->getPlugin(filterPluginName);
+    if (!filterPlugin) {
+        s2e->getWarningsStream() << "could not find filter plugin " << filterPluginName << "\n";
+        return nullptr;
+    }
+
+    ITracker *tracker = dynamic_cast<ITracker *>(filterPlugin);
+    if (!tracker) {
+        plugin->getWarningsStream() << filterPluginName << " must implement the ITracker interface\n";
+        return nullptr;
+    }
+
+    return tracker;
+}
+
+} // namespace plugins
+} // namespace s2e

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ITracker.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ITracker.h
@@ -1,0 +1,87 @@
+///
+/// Copyright (C) 2023, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#ifndef _ITRACKER_H_
+
+#define _ITRACKER_H_
+
+namespace s2e {
+
+class S2EExecutionState;
+class S2E;
+class Plugin;
+
+namespace plugins {
+
+///
+/// @brief Interface that plugins can use to implement tracking policies.
+///
+/// Execution tracing is very expensive when recording everything.
+/// We need users a flexible way to configure what guest code needs to be traced (the policy).
+/// Execution tracers should only focus on recording the trace data (the mechanism).
+/// It should be possible to mix and match tracers with tracking policies.
+/// For example, InstructionCounter should be configurable to count instructions in
+/// a specific, process, thread, or small piece of code. Same for TranslationBlockTracer.
+///
+class ITracker {
+public:
+    ///
+    /// @brief Signal that is triggered when a tracker's configuration changes.
+    ///
+    /// Guest code could, e.g., configure new threads to trace.
+    /// A tracing plugin may want to update its state as a result of that.
+    ///
+    sigc::signal<void, S2EExecutionState *> onConfigChange;
+
+    ///
+    /// @brief Indicates whether the guest code currently executing is being tracked.
+    ///
+    /// Execution tracers should call this API to determine whether to instrument
+    /// the code or not.
+    ///
+    /// TODO: the tracker should indicate the instrumentation granualarity:
+    /// - All translation blocks in the system.
+    /// - All translation blocks of a module.
+    /// Actual filtering is done on execution, so it would help to avoid instrumenting
+    /// codes unnecessarily.
+    ///
+    virtual bool isTrackedPc(S2EExecutionState *state, uint64_t pc) = 0;
+
+    bool isTracked(S2EExecutionState *state);
+
+    ///
+    /// @brief Indicates whether the tracker plugin is currently tracking something.
+    ///
+    /// This is useful to avoid instrumenting anything if there is nothing to be traced.
+    ///
+    virtual bool isTrackingConfigured(S2EExecutionState *state) = 0;
+
+    ///
+    /// @brief Plugins can use this to allow generic configuration of a tracker.
+    ///
+    static ITracker *getTracker(S2E *s2e, Plugin *plugin);
+};
+
+} // namespace plugins
+} // namespace s2e
+
+#endif

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/MemoryMap.cpp
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/MemoryMap.cpp
@@ -245,7 +245,7 @@ static void ComputeStartEndAddress(uint64_t address, uint64_t size, uint64_t &st
 }
 
 void MemoryMap::onLinuxMemoryMap(S2EExecutionState *state, uint64_t pid, uint64_t addr, uint64_t size, uint64_t prot) {
-    if (!m_proc->isTracked(state, pid)) {
+    if (!m_proc->isTrackedPid(state, pid)) {
         return;
     }
 
@@ -271,7 +271,7 @@ void MemoryMap::onLinuxMemoryMap(S2EExecutionState *state, uint64_t pid, uint64_
 }
 
 void MemoryMap::onLinuxMemoryUnmap(S2EExecutionState *state, uint64_t pid, uint64_t addr, uint64_t size) {
-    if (!m_proc->isTracked(state, pid)) {
+    if (!m_proc->isTrackedPid(state, pid)) {
         return;
     }
     uint64_t start, end;
@@ -282,7 +282,7 @@ void MemoryMap::onLinuxMemoryUnmap(S2EExecutionState *state, uint64_t pid, uint6
 }
 
 void MemoryMap::onDecreeUpdateMemoryMap(S2EExecutionState *state, uint64_t pid, const S2E_DECREEMON_VMA &vma) {
-    if (!m_proc->isTracked(state, pid)) {
+    if (!m_proc->isTrackedPid(state, pid)) {
         return;
     }
 
@@ -321,7 +321,7 @@ void MemoryMap::onNtAllocateVirtualMemory(S2EExecutionState *state, const S2E_WI
     uint64_t target_pid = m_windows->getPidFromHandle(state, pid, d.ProcessHandle);
     uint64_t real_pid = target_pid ? target_pid : pid;
 
-    if (!m_proc->isTracked(state, real_pid)) {
+    if (!m_proc->isTrackedPid(state, real_pid)) {
         return;
     }
 
@@ -354,7 +354,7 @@ void MemoryMap::onNtFreeVirtualMemory(S2EExecutionState *state, const S2E_WINMON
     uint64_t target_pid = m_windows->getPidFromHandle(state, pid, d.ProcessHandle);
     uint64_t real_pid = target_pid ? target_pid : pid;
 
-    if (!m_proc->isTracked(state, real_pid)) {
+    if (!m_proc->isTrackedPid(state, real_pid)) {
         return;
     }
 
@@ -378,7 +378,7 @@ void MemoryMap::onNtProtectVirtualMemory(S2EExecutionState *state, const S2E_WIN
     uint64_t target_pid = m_windows->getPidFromHandle(state, pid, d.ProcessHandle);
     uint64_t real_pid = target_pid ? target_pid : pid;
 
-    if (!m_proc->isTracked(state, real_pid)) {
+    if (!m_proc->isTrackedPid(state, real_pid)) {
         return;
     }
 
@@ -405,7 +405,7 @@ void MemoryMap::onNtMapViewOfSection(S2EExecutionState *state, const S2E_WINMON2
     uint64_t target_pid = m_windows->getPidFromHandle(state, pid, d.ProcessHandle);
     uint64_t real_pid = target_pid ? target_pid : pid;
 
-    if (!m_proc->isTracked(state, real_pid)) {
+    if (!m_proc->isTrackedPid(state, real_pid)) {
         return;
     }
 

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
@@ -188,6 +188,14 @@ bool ModuleExecutionDetector::getModuleConfig(const std::string &id, ModuleExecu
     return true;
 }
 
+bool ModuleExecutionDetector::isTrackedPc(S2EExecutionState *state, uint64_t pc) {
+    return getDescriptor(state, pc) != nullptr;
+}
+
+bool ModuleExecutionDetector::isTrackingConfigured(S2EExecutionState *state) {
+    return !m_configuredModules.empty();
+}
+
 /*****************************************************************************/
 /*****************************************************************************/
 /*****************************************************************************/

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.h
@@ -31,6 +31,7 @@
 #include <s2e/Plugin.h>
 #include <s2e/Plugins/Core/BaseInstructions.h>
 #include <s2e/Plugins/Core/Vmi.h>
+#include <s2e/Plugins/OSMonitors/Support/ITracker.h>
 #include <s2e/Plugins/OSMonitors/Support/ModuleMap.h>
 
 #include <inttypes.h>
@@ -93,7 +94,7 @@ typedef ConfiguredModules::index<modbyname_t>::type ConfiguredModulesByName;
 /// It is possible to set trackExecution to false in order to decrease the overhead,
 /// at the expense of not being notified when execution enters or leaves a configured
 /// module.
-class ModuleExecutionDetector : public Plugin {
+class ModuleExecutionDetector : public Plugin, public ITracker {
     S2E_PLUGIN
 
 public:
@@ -143,6 +144,10 @@ public:
     /// modules that the user configured.
     ///
     sigc::signal<void, S2EExecutionState *, const ModuleDescriptor &> onModuleLoad;
+
+    sigc::signal<void, S2EExecutionState *> onConfigChange;
+    bool isTrackedPc(S2EExecutionState *state, uint64_t pc);
+    bool isTrackingConfigured(S2EExecutionState *state);
 
 private:
     OSMonitor *m_monitor;

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/PidTid.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/PidTid.h
@@ -1,0 +1,45 @@
+///
+/// Copyright (C) 2023, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#ifndef __PIDTID_PLUGIN_H__
+
+#define __PIDTID_PLUGIN_H__
+
+#include <inttypes.h>
+
+namespace std {
+template <typename T1, typename T2> struct hash<std::pair<T1, T2>> {
+    std::size_t operator()(std::pair<T1, T2> const &p) const {
+        return p.first ^ p.second;
+    }
+};
+} // namespace std
+
+namespace s2e {
+namespace plugins {
+
+using PidTid = std::pair<uint64_t, uint64_t>;
+
+}
+} // namespace s2e
+
+#endif

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
@@ -74,6 +74,8 @@ void ProcessExecutionDetector::initialize() {
         m_trackedModules.insert(*it);
     }
 
+    m_traceKernel = cfg->getBool(getConfigKey() + ".traceKernel", false);
+
     m_monitor->onProcessLoad.connect(sigc::mem_fun(*this, &ProcessExecutionDetector::onProcessLoad));
 
     m_monitor->onProcessUnload.connect(sigc::mem_fun(*this, &ProcessExecutionDetector::onProcessUnload));
@@ -130,7 +132,7 @@ bool ProcessExecutionDetector::isTrackedPc(S2EExecutionState *state, uint64_t pc
         return false;
     }
 
-    if (m_monitor->isKernelAddress(pc)) {
+    if (!m_traceKernel && m_monitor->isKernelAddress(pc)) {
         return false;
     }
 

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
@@ -38,15 +38,17 @@ public:
     TrackedPids m_trackedPids;
 
     // Records whether the plugin has ever seen a configured process
-    bool m_hadTrackedProcesses;
+    bool m_hadTrackedProcesses = false;
+
+    bool m_trackKernel = false;
 
     virtual ProcessExecutionDetectorState *clone() const {
         ProcessExecutionDetectorState *ret = new ProcessExecutionDetectorState(*this);
         return ret;
     }
 
-    ProcessExecutionDetectorState() {
-        m_hadTrackedProcesses = false;
+    bool removePid(uint64_t pid) {
+        return m_trackedPids.erase(pid);
     }
 
     static PluginState *factory(Plugin *p, S2EExecutionState *s) {
@@ -74,7 +76,7 @@ void ProcessExecutionDetector::initialize() {
         m_trackedModules.insert(*it);
     }
 
-    m_traceKernel = cfg->getBool(getConfigKey() + ".traceKernel", false);
+    m_trackKernel = cfg->getBool(getConfigKey() + ".trackKernel", false);
 
     m_monitor->onProcessLoad.connect(sigc::mem_fun(*this, &ProcessExecutionDetector::onProcessLoad));
 
@@ -93,25 +95,33 @@ void ProcessExecutionDetector::onProcessLoad(S2EExecutionState *state, uint64_t 
 
         plgState->m_trackedPids.insert(pid);
         plgState->m_hadTrackedProcesses = true;
+        plgState->m_trackKernel = m_trackKernel;
+        onConfigChange.emit(state);
     }
 }
 
 void ProcessExecutionDetector::onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid,
                                                uint64_t returnCode) {
     DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
-    if (plgState->m_trackedPids.erase(pid)) {
+    if (plgState->removePid(pid)) {
         getDebugStream(state) << "Unloading process " << hexval(pid) << "\n";
         if (plgState->m_hadTrackedProcesses && plgState->m_trackedPids.size() == 0) {
             onAllProcessesTerminated.emit(state);
         }
+        onConfigChange.emit(state);
     }
 }
 
-bool ProcessExecutionDetector::isTracked(S2EExecutionState *state) {
-    return isTrackedPc(state, state->regs()->getPc());
+bool ProcessExecutionDetector::isTrackingConfigured(S2EExecutionState *state) {
+    DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
+    return !plgState->m_trackedPids.empty();
 }
 
-bool ProcessExecutionDetector::isTracked(S2EExecutionState *state, uint64_t pid) {
+bool ProcessExecutionDetector::isTrackedPc(S2EExecutionState *state, uint64_t pc) {
+    return isTrackedPc(state, pc, false);
+}
+
+bool ProcessExecutionDetector::isTrackedPid(S2EExecutionState *state, uint64_t pid) {
     DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
 
     if (plgState->m_trackedPids.size() == 0) {
@@ -121,7 +131,7 @@ bool ProcessExecutionDetector::isTracked(S2EExecutionState *state, uint64_t pid)
     return plgState->m_trackedPids.count(pid) > 0;
 }
 
-bool ProcessExecutionDetector::isTracked(const std::string &module) const {
+bool ProcessExecutionDetector::isTrackedModule(const std::string &module) const {
     return m_trackedModules.find(module) != m_trackedModules.end();
 }
 
@@ -132,7 +142,7 @@ bool ProcessExecutionDetector::isTrackedPc(S2EExecutionState *state, uint64_t pc
         return false;
     }
 
-    if (!m_traceKernel && m_monitor->isKernelAddress(pc)) {
+    if (!plgState->m_trackKernel && m_monitor->isKernelAddress(pc)) {
         return false;
     }
 
@@ -167,6 +177,35 @@ void ProcessExecutionDetector::onMonitorLoadCb(S2EExecutionState *state) {
 const TrackedPids &ProcessExecutionDetector::getTrackedPids(S2EExecutionState *state) const {
     DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
     return plgState->m_trackedPids;
+}
+
+void ProcessExecutionDetector::handleOpcodeInvocation(S2EExecutionState *state, uint64_t guestDataPtr,
+                                                      uint64_t guestDataSize) {
+    DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
+
+    S2E_PROCEXECDETECTOR_COMMAND command;
+
+    if (guestDataSize != sizeof(command)) {
+        getWarningsStream(state) << "mismatched S2E_PROCEXECDETECTOR_COMMAND size\n";
+        exit(-1);
+    }
+
+    if (!state->mem()->read(guestDataPtr, &command, guestDataSize)) {
+        getWarningsStream(state) << "could not read transmitted data\n";
+        exit(-1);
+    }
+
+    switch (command.Command) {
+        case PROCEXEC_ENABLE_PID:
+            plgState->m_trackedPids.insert(command.Pid);
+            break;
+
+        case PROCEXEC_DISABLE_PID:
+            plgState->m_trackedPids.erase(command.Pid);
+            break;
+    }
+
+    onConfigChange.emit(state);
 }
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.h
@@ -38,6 +38,9 @@ typedef llvm::DenseSet<uint64_t> TrackedPids;
 
 class ProcessExecutionDetector : public Plugin {
     S2E_PLUGIN
+
+    bool m_traceKernel = false;
+
 public:
     ProcessExecutionDetector(S2E *s2e) : Plugin(s2e) {
     }

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.h
@@ -25,9 +25,14 @@
 
 #include <s2e/CorePlugin.h>
 #include <s2e/Plugin.h>
+#include <s2e/Plugins/Core/BaseInstructions.h>
 #include <s2e/S2EExecutionState.h>
 
 #include <llvm/ADT/DenseSet.h>
+
+#include <s2e/monitors/support/process_execution_detector.h>
+
+#include "ITracker.h"
 
 namespace s2e {
 namespace plugins {
@@ -36,10 +41,16 @@ class OSMonitor;
 
 typedef llvm::DenseSet<uint64_t> TrackedPids;
 
-class ProcessExecutionDetector : public Plugin {
+///
+/// @brief This class allows clients plugins to instrument code running
+/// inside processes of interest.
+///
+/// This plugin can be configured from the lua file or dynamically from
+/// the guest, using the APIs in the guest header file. It is possible
+/// to enable/disable which PIDs are tracked at runtime.
+///
+class ProcessExecutionDetector : public Plugin, public IPluginInvoker, public ITracker {
     S2E_PLUGIN
-
-    bool m_traceKernel = false;
 
 public:
     ProcessExecutionDetector(S2E *s2e) : Plugin(s2e) {
@@ -47,10 +58,11 @@ public:
 
     void initialize();
 
-    bool isTracked(S2EExecutionState *state);
-    bool isTracked(S2EExecutionState *state, uint64_t pid);
-    bool isTracked(const std::string &module) const;
-    bool isTrackedPc(S2EExecutionState *state, uint64_t pc, bool checkCpl = false);
+    bool isTrackingConfigured(S2EExecutionState *state);
+    bool isTrackedPc(S2EExecutionState *state, uint64_t pc);
+    bool isTrackedPid(S2EExecutionState *state, uint64_t pid);
+    bool isTrackedModule(const std::string &module) const;
+    bool isTrackedPc(S2EExecutionState *state, uint64_t pc, bool checkCpl);
 
     void trackPid(S2EExecutionState *state, uint64_t pid);
 
@@ -66,10 +78,14 @@ private:
 
     StringSet m_trackedModules;
 
+    bool m_trackKernel = false;
+
     void onProcessLoad(S2EExecutionState *state, uint64_t pageDir, uint64_t pid, const std::string &ImageFileName);
     void onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid, uint64_t returnCode);
 
     void onMonitorLoadCb(S2EExecutionState *state);
+
+    void handleOpcodeInvocation(S2EExecutionState *state, uint64_t guestDataPtr, uint64_t guestDataSize);
 };
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ThreadExecutionDetector.cpp
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ThreadExecutionDetector.cpp
@@ -1,0 +1,174 @@
+///
+/// Copyright (C) 2023, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#include <unordered_set>
+
+#include <s2e/ConfigFile.h>
+#include <s2e/Plugins/OSMonitors/OSMonitor.h>
+#include <s2e/S2E.h>
+#include <s2e/Utils.h>
+#include <s2e/cpu.h>
+
+#include <s2e/Plugins/OSMonitors/Support/PidTid.h>
+#include <s2e/Plugins/OSMonitors/Support/ThreadExecutionDetector.h>
+
+namespace s2e {
+namespace plugins {
+
+S2E_DEFINE_PLUGIN(ThreadExecutionDetector, "ThreadExecutionDetector S2E plugin", "", "OSMonitor");
+
+class ThreadExecutionDetectorState : public PluginState {
+public:
+    using TrackedPidsTids = std::unordered_set<PidTid>;
+
+    TrackedPidsTids m_trackedPidsTids;
+
+    bool m_trackKernel = false;
+
+    bool m_tracked = false;
+
+    virtual ThreadExecutionDetectorState *clone() const {
+        return new ThreadExecutionDetectorState(*this);
+    }
+
+    void addPidTid(uint64_t pid, uint64_t tid) {
+        m_trackedPidsTids.insert(PidTid(pid, tid));
+    }
+
+    bool removePid(uint64_t pid) {
+        std::vector<PidTid> toErase;
+        for (const auto &pt : m_trackedPidsTids) {
+            if (pt.first == pid) {
+                toErase.push_back(pt);
+            }
+        }
+
+        for (const auto &pt : toErase) {
+            m_trackedPidsTids.erase(pt);
+        }
+
+        return toErase.size() > 0;
+    }
+
+    void removePidTid(uint64_t pid, uint64_t tid) {
+        m_trackedPidsTids.erase(PidTid(pid, tid));
+    }
+
+    static PluginState *factory(Plugin *p, S2EExecutionState *s) {
+        return new ThreadExecutionDetectorState();
+    }
+
+    virtual ~ThreadExecutionDetectorState() {
+    }
+};
+
+void ThreadExecutionDetector::initialize() {
+    m_monitor = static_cast<OSMonitor *>(s2e()->getPlugin("OSMonitor"));
+    m_monitor->onProcessUnload.connect(sigc::mem_fun(*this, &ThreadExecutionDetector::onProcessUnload));
+}
+
+void ThreadExecutionDetector::onThreadExit(S2EExecutionState *state, const ThreadDescriptor &thread) {
+    DECLARE_PLUGINSTATE(ThreadExecutionDetectorState, state);
+    plgState->removePidTid(thread.Pid, thread.Tid);
+}
+
+void ThreadExecutionDetector::onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid,
+                                              uint64_t returnCode) {
+    DECLARE_PLUGINSTATE(ThreadExecutionDetectorState, state);
+    plgState->removePid(pid);
+}
+
+bool ThreadExecutionDetector::isTrackingConfigured(S2EExecutionState *state) {
+    DECLARE_PLUGINSTATE(ThreadExecutionDetectorState, state);
+    return !plgState->m_trackedPidsTids.empty();
+}
+
+bool ThreadExecutionDetector::isTrackedPc(S2EExecutionState *state, uint64_t pc) {
+    DECLARE_PLUGINSTATE(ThreadExecutionDetectorState, state);
+
+    // Ignore 16-bit mode.
+    if ((env->hflags >> HF_VM_SHIFT) & 1) {
+        return false;
+    }
+
+    auto hasPidsTids = plgState->m_trackedPidsTids.size() > 0;
+    if (!hasPidsTids) {
+        return false;
+    }
+
+    if (!plgState->m_trackKernel && m_monitor->isKernelAddress(pc)) {
+        return false;
+    }
+
+    auto pid = m_monitor->getPid(state);
+    auto tid = m_monitor->getTid(state);
+
+    auto tracked_thread = plgState->m_trackedPidsTids.count(PidTid(pid, tid)) > 0;
+
+    return tracked_thread;
+}
+
+void ThreadExecutionDetector::handleOpcodeInvocation(S2EExecutionState *state, uint64_t guestDataPtr,
+                                                     uint64_t guestDataSize) {
+    DECLARE_PLUGINSTATE(ThreadExecutionDetectorState, state);
+
+    S2E_THREADEXECDETECTOR_COMMAND command;
+
+    if (guestDataSize != sizeof(command)) {
+        getWarningsStream(state) << "mismatched S2E_THREADEXECDETECTOR_COMMAND size\n";
+        exit(-1);
+    }
+
+    if (!state->mem()->read(guestDataPtr, &command, guestDataSize)) {
+        getWarningsStream(state) << "could not read transmitted data\n";
+        exit(-1);
+    }
+
+    switch (command.Command) {
+        case THREADEXEC_ENABLE_KERNEL_TRACKING:
+            plgState->m_trackKernel = true;
+            break;
+
+        case THREADEXEC_DISABLE_KERNEL_TRACKING:
+            plgState->m_trackKernel = false;
+            break;
+
+        case THREADEXEC_ENABLE_CURRENT: {
+            auto pid = m_monitor->getPid(state);
+            auto tid = m_monitor->getTid(state);
+            plgState->addPidTid(pid, tid);
+            plgState->m_tracked = true;
+        } break;
+
+        case THREADEXEC_DISABLE_CURRENT: {
+            auto pid = m_monitor->getPid(state);
+            auto tid = m_monitor->getTid(state);
+            plgState->removePidTid(pid, tid);
+            plgState->m_tracked = false;
+        } break;
+    }
+
+    onConfigChange.emit(state);
+}
+
+} // namespace plugins
+} // namespace s2e

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ThreadExecutionDetector.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Support/ThreadExecutionDetector.h
@@ -1,0 +1,73 @@
+///
+/// Copyright (C) 2023, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#ifndef S2E_PLUGINS_ThreadExecutionDetector_H
+#define S2E_PLUGINS_ThreadExecutionDetector_H
+
+#include <s2e/CorePlugin.h>
+#include <s2e/Plugin.h>
+#include <s2e/Plugins/Core/BaseInstructions.h>
+#include <s2e/S2EExecutionState.h>
+
+#include <llvm/ADT/DenseSet.h>
+
+#include <s2e/monitors/support/thread_execution_detector.h>
+
+#include "ITracker.h"
+
+namespace s2e {
+namespace plugins {
+
+class OSMonitor;
+
+///
+/// @brief This class allows clients plugins to instrument code running
+/// inside threads of interest.
+///
+/// This plugin can only be configured from guest code. The guest header file
+/// provides APIs to enable/disable tracking for the thread they are called from
+/// as well as enable/disable kernel tracking in the context of that thread.
+///
+class ThreadExecutionDetector : public Plugin, public IPluginInvoker, public ITracker {
+    S2E_PLUGIN
+
+public:
+    ThreadExecutionDetector(S2E *s2e) : Plugin(s2e) {
+    }
+
+    void initialize();
+
+    bool isTrackedPc(S2EExecutionState *state, uint64_t pc);
+    bool isTrackingConfigured(S2EExecutionState *state);
+
+private:
+    OSMonitor *m_monitor;
+
+    void onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid, uint64_t returnCode);
+    void onThreadExit(S2EExecutionState *state, const ThreadDescriptor &thread);
+    void handleOpcodeInvocation(S2EExecutionState *state, uint64_t guestDataPtr, uint64_t guestDataSize);
+};
+
+} // namespace plugins
+} // namespace s2e
+
+#endif // S2E_PLUGINS_ThreadExecutionDetector_H

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Windows/WindowsMonitor.h
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Windows/WindowsMonitor.h
@@ -261,8 +261,6 @@ public:
 
     void initialize();
 
-    sigc::signal<void, S2EExecutionState *> onProcessOrThreadSwitch;
-
     sigc::signal<void, S2EExecutionState *, const S2E_WINMON2_ACCESS_FAULT &> onAccessFault;
 
     sigc::signal<void, S2EExecutionState *, const S2E_WINMON2_ALLOCATE_VM &> onNtAllocateVirtualMemory;

--- a/libs2eplugins/src/s2e/Plugins/VulnerabilityAnalysis/DecreePovGenerator.cpp
+++ b/libs2eplugins/src/s2e/Plugins/VulnerabilityAnalysis/DecreePovGenerator.cpp
@@ -882,7 +882,7 @@ bool DecreePovGenerator::isReceiveRead(const ref<Expr> &e) {
 
 void DecreePovGenerator::onWrite(S2EExecutionState *state, uint64_t pid, uint64_t fd,
                                  const std::vector<ref<Expr>> &data, ref<Expr> sizeExpr) {
-    if (!m_detector->isTracked(state, pid)) {
+    if (!m_detector->isTrackedPid(state, pid)) {
         return;
     }
 
@@ -896,7 +896,7 @@ void DecreePovGenerator::onWrite(S2EExecutionState *state, uint64_t pid, uint64_
 void DecreePovGenerator::onSymbolicRead(S2EExecutionState *state, uint64_t pid, uint64_t fd, uint64_t size,
                                         const std::vector<std::pair<std::vector<ref<Expr>>, std::string>> &data,
                                         ref<Expr> sizeExpr) {
-    if (!m_detector->isTracked(state, pid)) {
+    if (!m_detector->isTrackedPid(state, pid)) {
         return;
     }
 
@@ -913,7 +913,7 @@ void DecreePovGenerator::onSymbolicRead(S2EExecutionState *state, uint64_t pid, 
 
 void DecreePovGenerator::onConcreteRead(S2EExecutionState *state, uint64_t pid, uint64_t fd,
                                         const std::vector<uint8_t> &data) {
-    if (!m_detector->isTracked(state, pid)) {
+    if (!m_detector->isTrackedPid(state, pid)) {
         return;
     }
 

--- a/libs2eplugins/src/s2e/Plugins/VulnerabilityAnalysis/PovGenerationPolicy.cpp
+++ b/libs2eplugins/src/s2e/Plugins/VulnerabilityAnalysis/PovGenerationPolicy.cpp
@@ -142,7 +142,7 @@ void PovGenerationPolicy::onSegFaultWinKernel(S2EExecutionState *state,
 }
 
 void PovGenerationPolicy::onSegFault(S2EExecutionState *state, uint64_t pid, uint64_t pc) {
-    if (!m_process->isTracked(state, pid)) {
+    if (!m_process->isTrackedPid(state, pid)) {
         // Only dump memory on decree, because it has relatively small binaries
         if (m_decreeMonitor) {
             std::stringstream ss;

--- a/testsuite/basic11-icount/Makefile
+++ b/testsuite/basic11-icount/Makefile
@@ -1,0 +1,47 @@
+# Copyright (c) 2023, Vitaly Chipounov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+TARGET=basic11-icount
+SOURCE=main.c
+
+GCC_LINUX=gcc
+GCC_WINDOWS64=x86_64-w64-mingw32-gcc
+GCC_WINDOWS32=i686-w64-mingw32-gcc
+
+CFLAGS:=$(CFLAGS) -O0 -g -Wall -std=c99 -fno-plt -static
+LDFLAGS:=$(LDFLAGS) -lpthread
+
+linux64-$(TARGET): $(SOURCE)
+	$(GCC_LINUX) -m64 $(CFLAGS) -o "$@" "$^" $(LDFLAGS)
+
+linux32-$(TARGET): $(SOURCE)
+	$(GCC_LINUX) -m32 $(CFLAGS) -o "$@" "$^" $(LDFLAGS)
+
+windows64-$(TARGET).exe: $(SOURCE)
+	$(GCC_WINDOWS64) -m64 $(CFLAGS) -o "$@" "$^" $(LDFLAGS)
+
+windows32-$(TARGET).exe: $(SOURCE)
+	$(GCC_WINDOWS32) -m32 $(CFLAGS) -o "$@" "$^" $(LDFLAGS)
+
+TARGETS=linux64-$(TARGET) linux32-$(TARGET) windows64-$(TARGET).exe windows32-$(TARGET).exe
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)

--- a/testsuite/basic11-icount/config.yml
+++ b/testsuite/basic11-icount/config.yml
@@ -1,0 +1,11 @@
+test:
+    description: "Check that InstructionCounter works properly"
+
+    targets:
+        - windows64-basic11-icount.exe
+        - windows32-basic11-icount.exe
+        - linux32-basic11-icount
+        - linux64-basic11-icount
+    
+    build-options:
+        post-project-generation-script: fix-config.sh

--- a/testsuite/basic11-icount/fix-config.sh
+++ b/testsuite/basic11-icount/fix-config.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+echo "Patching s2e-config.lua..."
+
+. ${TESTSUITE_ROOT}/helpers.sh
+
+PROJECT_NAME="$(basename $PROJECT_DIR)"
+
+PLATFORM=$(get_platform "$TARGET")
+
+cat << EOF >> $PROJECT_DIR/s2e-config.lua
+
+add_plugin("InstructionCounter")
+pluginsConfig.InstructionCounter = {
+    filterPlugin = "ThreadExecutionDetector"
+}
+
+add_plugin("ThreadExecutionDetector")
+add_plugin("TranslationBlockTracer")
+pluginsConfig.TranslationBlockTracer = {
+    traceTbStart = true,
+    filterPlugin = "ThreadExecutionDetector"
+}
+
+EOF

--- a/testsuite/basic11-icount/main.c
+++ b/testsuite/basic11-icount/main.c
@@ -1,0 +1,195 @@
+// Copyright (c) 2023, Vitaly Chipounov
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#define _GNU_SOURCE
+
+#include <inttypes.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <s2e/instruction_counter.h>
+#include <s2e/monitors/support/thread_execution_detector.h>
+#include <s2e/s2e.h>
+
+// TODO: move the OS abstractions into a separate header file so
+// that other tests can use them as well.
+#ifdef _WIN32
+#include <windows.h>
+
+typedef HANDLE thread_t;
+
+thread_t our_create_thread(void *fn) {
+    return CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) fn, NULL, 0, NULL);
+}
+
+void our_thread_join(thread_t handle) {
+    WaitForSingleObject((HANDLE) handle, INFINITE);
+}
+
+pid_t our_gettid(void) {
+    return GetCurrentThreadId();
+}
+#else
+#include <pthread.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+typedef pthread_t thread_t;
+
+thread_t our_create_thread(void *fn) {
+    pthread_t id;
+    if (pthread_create(&id, NULL, fn, NULL) < 0) {
+        return -1;
+    }
+
+    return id;
+}
+
+void our_thread_join(thread_t handle) {
+    void *result;
+    pthread_join(handle, (void **) &result);
+}
+
+pid_t our_gettid(void) {
+    return syscall(SYS_gettid);
+}
+#endif
+
+// Each loop iteration records the current value of the
+// instruction counter. It must increase by a constant
+// number of instructions at each iteration.
+static void *test_icount(void *arg) {
+
+    // Count instructions only within a small block of code.
+    s2e_thread_exec_enable_current();
+    s2e_icount_reset();
+    uint64_t counts[16];
+
+    for (int i = 0; i < 16; ++i) {
+        counts[i] = s2e_icount_get();
+        if (counts[i] == 0) {
+            s2e_kill_state(0, "Got zero count");
+        }
+    }
+
+    s2e_thread_exec_disable_current();
+
+    uint64_t first_diff = 0;
+    int fail = 0;
+
+    pid_t pid = getpid();
+    pid_t tid = our_gettid();
+
+    // Check that instruction counts are constant.
+    for (int i = 0; i < 16; ++i) {
+        uint64_t diff = 0;
+        if (i > 0) {
+            diff = counts[i] - counts[i - 1];
+            if (i == 1) {
+                first_diff = diff;
+            } else {
+                if (diff != first_diff) {
+                    fail = 1;
+                }
+            }
+        }
+
+        s2e_printf("pid=%d tid=%d icount[%d]=%" PRIu64 " diff=%" PRIu64, pid, tid, i, counts[i], diff);
+
+        if (i > 0) {
+            if (counts[i] == 0 || diff == 0) {
+                s2e_kill_state(0, "incorrect count/diff");
+            }
+        }
+    }
+
+    if (fail) {
+        s2e_kill_state(0, "icount bad");
+    }
+
+    return NULL;
+}
+
+static void invoke_syscall(void) {
+#ifdef _WIN32
+    // That's not a pid, but we don't really care.
+    // We just want some syscall.
+    // On Windows, getpid() doesn't result in a syscall.
+    OpenProcess(READ_CONTROL, FALSE, 1234);
+#else
+    getpid();
+#endif
+}
+
+///
+/// @brief Test that the instruction counter properly handles syscalls.
+///
+/// It must be able to count kernel instructions when the tracking plugin
+/// is instructed to track the kernel.
+///
+static int test_icount_syscall(int trace_kernel) {
+    s2e_thread_exec_enable_current();
+    if (trace_kernel) {
+        s2e_thread_exec_enable_kernel_tracking();
+    }
+
+    s2e_icount_reset();
+
+    invoke_syscall();
+
+    int icount = s2e_icount_get();
+
+    if (trace_kernel) {
+        s2e_thread_exec_disable_kernel_tracking();
+    }
+
+    s2e_thread_exec_disable_current();
+
+    s2e_printf("trace_kernel=%d icount=%d\n", trace_kernel, icount);
+
+    return icount;
+}
+
+int main(int argc, char **argv) {
+    thread_t threads[16];
+
+    int c1 = test_icount_syscall(0);
+    int c2 = test_icount_syscall(1);
+    if (!c1 || !c2) {
+        s2e_kill_state(0, "icount is zero");
+    }
+
+    if (c2 <= c1) {
+        s2e_kill_state(0, "icount is wrong");
+    }
+
+    for (int i = 0; i < 16; ++i) {
+        threads[i] = our_create_thread(test_icount);
+    }
+
+    for (int i = 0; i < 16; ++i) {
+        our_thread_join(threads[i]);
+    }
+
+    s2e_kill_state(0, "icount good");
+
+    return 0;
+}

--- a/testsuite/basic11-icount/run-tests.tpl
+++ b/testsuite/basic11-icount/run-tests.tpl
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+{% include 'common-run.sh.tpl' %}
+
+s2e run -n {{ project_name }}
+
+grep -q "icount good" $S2E_LAST/debug.txt
+
+s2e execution_trace -pp {{ project_name }}

--- a/testsuite/basic8-tracers/fix-config.sh
+++ b/testsuite/basic8-tracers/fix-config.sh
@@ -17,19 +17,19 @@ pluginsConfig.MemoryTracer = {
     traceMemory = true,
     traceTlbMisses = true,
     tracePageFaults = true,
-    moduleNames = {"$(basename $TARGET)"}
+    filterPlugin = "ModuleExecutionDetector"
 }
 
 add_plugin("TranslationBlockTracer")
 pluginsConfig.TranslationBlockTracer = {
     traceTbStart = true,
     traceTbEnd = true,
-    moduleNames = {"$(basename $TARGET)"}
+    filterPlugin = "ModuleExecutionDetector"
 }
 
 add_plugin("InstructionCounter")
 pluginsConfig.InstructionCounter = {
-    moduleNames = {"$(basename $TARGET)"}
+    filterPlugin = "ModuleExecutionDetector"
 }
 
 EOF


### PR DESCRIPTION
To count instructions in the kernel, add `traceKernel` to the config of `ProcessExecutionDetector`.

InstructionCounter also supports two guest commands:
- s2e_icount_reset
- s2e_icount_get

Refer to the test case for how to use them.

https://github.com/S2E/s2e-env/issues/489