### PR TITLE
libs2eplugins/LibraryCallMonitor: add exportName in onLibraryCall signal

### DIFF
--- a/libs2eplugins/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.cpp
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.cpp
@@ -229,7 +229,7 @@ void LibraryCallMonitor::onIndirectCallOrJump(S2EExecutionState *state, uint64_t
     }
 
     logLibraryCall(state, *currentMod.get(), *mod.get(), pc, targetAddr, sourceType, exportName);
-    onLibraryCall.emit(state, *mod, targetAddr);
+    onLibraryCall.emit(state, *mod, targetAddr, exportName);
 }
 
 } // namespace plugins

--- a/libs2eplugins/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.h
+++ b/libs2eplugins/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.h
@@ -77,7 +77,8 @@ public:
     /// Emitted on an external library function call.
     sigc::signal<void, S2EExecutionState *, /* The current execution state */
                  const ModuleDescriptor &,  /* The module that is being called */
-                 uint64_t>                  /* The called function's address */
+                 uint64_t,                  /* The called function's address */
+                 const std::string &>       /* The called function's name */
         onLibraryCall;
 
 private:


### PR DESCRIPTION
As discussed here (https://groups.google.com/g/s2e-dev/c/KumALD_qpkE), I exposed the `exportName` in the `onLibraryCall` signal.

Even though the signal is not connected by other plugins in this repo, this change may cause an error in end user's local development environment. I can write a function in `LibraryCallMontor`  plugin, which returns `exportName`  given state, module, and target address, as a workaround.

Let me know what you think.

Signed-off-by: Mingxuan Yao <mingxuanyao@hotmail.com>