### PR TITLE
libq: fix the undeclared ERANGE in json-parser

### DIFF
--- a/libq/include/qapi/error.h
+++ b/libq/include/qapi/error.h
@@ -272,6 +272,7 @@
 #ifndef ERROR_H
 #define ERROR_H
 
+#include <errno.h>
 #include <glib.h>
 
 #include "util.h"

--- a/libq/src/error.c
+++ b/libq/src/error.c
@@ -13,7 +13,6 @@
  */
 
 #include <assert.h>
-#include <errno.h>
 #include <stdio.h>
 
 #include "qapi/error.h"


### PR DESCRIPTION
The `ERANGE` used in `json-parser.c` is in `errno.h`, which is not included. Found this error when I tried build s2e with debug information. I added the include in `qapi/error.h` and removed the `errno.h` include from `error.c` file.

Signed-off-by: Mingxuan Yao <mingxuanyao@hotmail.com>