### PR TITLE
libcpu/softmmu_template: fixed symbolic hardware mmio

### DIFF
--- a/libcpu/src/softmmu_template.h
+++ b/libcpu/src/softmmu_template.h
@@ -234,7 +234,7 @@ DATA_TYPE glue(glue(io_read_chk, SUFFIX), MMUSUFFIX)(CPUArchState *env, target_p
     res.res = glue(glue(io_read, SUFFIX), MMUSUFFIX)(env, origaddr, addr, retaddr);
 
 end:
-    tcg_llvm_trace_mmio_access(addr, res.res, DATA_SIZE, 0);
+    res.res = tcg_llvm_trace_mmio_access(addr, res.res, DATA_SIZE, 0);
 
     SE_SET_MEM_IO_VADDR(env, 0, 1);
     return res.res;


### PR DESCRIPTION
The io_read_chk function failed to handle the value returned by tcg_llvm_trace_mmio_access, causing the SymbolicHardware plugin to malfunction.