### PR TITLE
More accurate maxForkCount in ForkLimiter

### DIFF
--- a/libs2eplugins/src/s2e/Plugins/PathLimiters/ForkLimiter.cpp
+++ b/libs2eplugins/src/s2e/Plugins/PathLimiters/ForkLimiter.cpp
@@ -71,7 +71,7 @@ void ForkLimiter::onStateForkDecide(S2EExecutionState *state, const klee::ref<kl
         return;
     }
 
-    if (m_forkCount[module->Name][curPc] > m_limit) {
+    if (m_forkCount[module->Name][curPc] >= m_limit) {
         allowForking = false;
     }
 }


### PR DESCRIPTION
In the current logic, the `maxForkCount` in the ForkLimiter actually allows `maxForkCount+1` forks.

For example, if we set `maxForkCount` to 0, at the first attempt to fork, the following check:
```cpp
m_forkCount[module->Name][curPc] > m_limit
```

, which equals to `0 > 0` is false, so the fork is allowed.