### PR TITLE
Use pre-compiled LLVM

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: Build libs2e.so
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install packages
+        run: |
+            set -ex
+            sudo dpkg --add-architecture i386 && sudo apt-get update
+            sudo apt-get -y install ca-certificates build-essential curl wget texinfo flex bison  \
+              python-is-python3 python3-dev python3-venv python3-distro mingw-w64 lsb-release \
+              libdwarf-dev libelf-dev libelf-dev:i386 \
+              libboost-dev zlib1g-dev libjemalloc-dev nasm pkg-config                 \
+              libmemcached-dev libpq-dev libc6-dev-i386 binutils-dev                  \
+              libboost-system-dev libboost-serialization-dev libboost-regex-dev       \
+              libbsd-dev libpixman-1-dev                                              \
+              libglib2.0-dev libglib2.0-dev:i386 python3-docutils libpng-dev          \
+              gcc-multilib g++-multilib libgomp1 unzip
+
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y software-properties-common
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test && sudo apt update
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y gcc-9 g++-9
+
+      - name: Build libs2e.so
+        run: |
+           set -x
+           cd ..
+           mkdir build && cd build
+           make -f ../s2e/Makefile all-release
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -2,7 +2,7 @@ name: Check code style
 on: [pull_request]
 jobs:
   clang-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ FROM ubuntu:22.04
 # Install build dependencies
 RUN dpkg --add-architecture i386 && apt-get update &&                       \
     apt-get -y install ca-certificates build-essential curl wget texinfo flex bison  \
-    python-is-python3 python3-dev python3-venv python3-distro mingw-w64 lsb-release
+    python-is-python3 python3-dev python3-venv python3-distro mingw-w64 lsb-release \
+    autoconf libtool
 
 # Install S2E dependencies
 RUN apt-get update && apt-get -y install libdwarf-dev libelf-dev libelf-dev:i386 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,6 @@ RUN mkdir s2e
 RUN mkdir s2e-build
 COPY Makefile s2e/
 COPY scripts/determine_clang_binary_suffix.py s2e/scripts/
-RUN cd s2e-build &&                                                         \
-    make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/clang-binary
 
 RUN cd s2e-build &&                                                         \
     make -f ../s2e/Makefile S2E_PREFIX=/opt/s2e stamps/llvm-release-make

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,24 @@
+# Copyright (C) 2014-2023 Cyberhaven
+# Copyright (C) 2010-2014 Dependable Systems Laboratory, EPFL
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # Environment variables:
 #
 #  PARALLEL=no
@@ -30,6 +51,7 @@ BUILD_SCRIPTS_SRC?=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))/scripts
 S2E_SRC?=$(realpath $(BUILD_SCRIPTS_SRC)/../)
 S2E_PREFIX?=$(CURDIR)/opt
 S2E_BUILD:=$(CURDIR)
+
 
 # Build Z3 from binary (default, "yes") or source ("no")
 USE_Z3_BINARY?=yes
@@ -77,32 +99,15 @@ ifeq ($(LLVM_BUILD),$(S2E_BUILD))
 LLVM_DIRS=llvm-release llvm-debug
 endif
 
-# More recent point releases don't have the Ubuntu binaries yet, so stick with 14.0.0.
-LLVM_VERSION=14.0.0
-LLVM_SRC=llvm-$(LLVM_VERSION).src.tar.xz
-LLVM_SRC_DIR=llvm-$(LLVM_VERSION).src
-LLVM_SRC_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VERSION)/
+CLANG_LLVM=clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04
+CLANG_LLVM_DEBUG_ARCHIVE=$(CLANG_LLVM)-debug.tar.xz
+CLANG_LLVM_DEBUG_URL=https://github.com/S2E/s2e/releases/download/v2.0.0/$(CLANG_LLVM_DEBUG_ARCHIVE)
 
-# The Python script should only return a single word - the suffix of the Clang
-# binary to download. If an error message is printed to stderr, the Makefile
-# error will be triggered.
-CLANG_BINARY_SUFFIX=$(shell $(BUILD_SCRIPTS_SRC)/determine_clang_binary_suffix.py 2>&1)
-ifneq ($(words $(CLANG_BINARY_SUFFIX)), 1)
-$(error "Failed to determine Clang binary to download: $(CLANG_BINARY_SUFFIX)")
-endif
+CLANG_LLVM_RELEASE_ARCHIVE=$(CLANG_LLVM)-release.tar.xz
+CLANG_LLVM_RELEASE_URL=https://github.com/S2E/s2e/releases/download/v2.0.0/$(CLANG_LLVM_RELEASE_ARCHIVE)
+
 
 KLEE_DIRS=$(foreach suffix,-debug -release -coverage,$(addsuffix $(suffix),klee))
-
-CLANG_BINARY_DIR=clang+llvm-$(LLVM_VERSION)-$(CLANG_BINARY_SUFFIX)
-CLANG_BINARY=$(CLANG_BINARY_DIR).tar.xz
-
-CLANG_SRC=clang-$(LLVM_VERSION).src.tar.xz
-CLANG_SRC_DIR=clang-$(LLVM_VERSION).src
-CLANG_DEST_DIR=$(LLVM_SRC_DIR)/tools/clang
-
-COMPILER_RT_SRC=compiler-rt-$(LLVM_VERSION).src.tar.xz
-COMPILER_RT_SRC_DIR=compiler-rt-$(LLVM_VERSION).src
-COMPILER_RT_DEST_DIR=$(LLVM_SRC_DIR)/projects/compiler-rt
 
 # Capstone variables
 CAPSTONE_VERSION=4.0.2
@@ -177,10 +182,10 @@ guest-tools-win-install: stamps/guest-tools32-win-install stamps/guest-tools64-w
 
 install: all-release stamps/libs2e-release-install stamps/tools-release-install \
     stamps/libvmi-release-install guest-tools-install     \
-    guest-tools-win-install stamps/llvm-release-install
+    guest-tools-win-install
 install-debug: all-debug stamps/libs2e-debug-install stamps/tools-debug-install \
     stamps/libvmi-debug-install guest-tools-install       \
-    guest-tools-win-install stamps/llvm-release-install
+    guest-tools-win-install
 
 # From https://stackoverflow.com/questions/4219255/how-do-you-get-the-list-of-targets-in-a-makefile
 list:
@@ -218,29 +223,12 @@ define DOWNLOAD
 curl -f -L "$1" -o "$2"
 endef
 
-
-ifeq ($(LLVM_BUILD),$(S2E_BUILD))
 # Download LLVM
-$(LLVM_SRC) $(CLANG_SRC) $(COMPILER_RT_SRC) $(CLANG_BINARY):
-	$(call DOWNLOAD,$(LLVM_SRC_URL)/$@,$@)
+$(CLANG_LLVM_DEBUG_ARCHIVE):
+	$(call DOWNLOAD,$(CLANG_LLVM_DEBUG_URL),$@)
 
-
-.INTERMEDIATE: $(CLANG_SRC_DIR) $(COMPILER_RT_SRC_DIR) $(CLANG_BINARY_DIR)
-
-$(LLVM_SRC_DIR): $(LLVM_SRC) $(CLANG_SRC_DIR) $(COMPILER_RT_SRC_DIR)
-	tar -xmf $<
-	mv $(CLANG_SRC_DIR) $(CLANG_DEST_DIR)
-	mv $(COMPILER_RT_SRC_DIR) $(COMPILER_RT_DEST_DIR)
-
-$(CLANG_SRC_DIR): $(CLANG_SRC)
-	tar -xmf $<
-
-$(COMPILER_RT_SRC_DIR): $(COMPILER_RT_SRC)
-	tar -xmf $<
-
-else
-# Use the specified LLVM build folder, don't build LLVM
-endif
+$(CLANG_LLVM_RELEASE_ARCHIVE):
+	$(call DOWNLOAD,$(CLANG_LLVM_RELEASE_URL),$@)
 
 # Download Lua
 $(LUA_SRC):
@@ -290,67 +278,22 @@ $(PROTOBUF_BUILD_DIR):
 	tar -zxf $(S2E_BUILD)/$(PROTOBUF_SRC_DIR).tar.gz
 	mkdir -p $(S2E_BUILD)/$(PROTOBUF_BUILD_DIR)
 
-ifeq ($(LLVM_BUILD),$(S2E_BUILD))
-
-
 ########
 # LLVM #
 ########
-
-stamps/clang-binary: $(CLANG_BINARY) | stamps
-	tar -xmf $<
-	mkdir -p $(S2E_PREFIX)
-	cp -r $(CLANG_BINARY_DIR)/* $(S2E_PREFIX)
-	rm -r $(CLANG_BINARY_DIR)/*
+stamps/llvm-release-make: $(CLANG_LLVM_RELEASE_ARCHIVE) | stamps
+	mkdir -p "$(S2E_BUILD)/llvm-release"
+	tar -Jxf $< --transform s/$(CLANG_LLVM)/llvm-release/
 	touch $@
 
-CLANG_CC = $(S2E_PREFIX)/bin/clang
-CLANG_CXX = $(S2E_PREFIX)/bin/clang++
-CLANG_LIB = $(S2E_PREFIX)/lib
+stamps/llvm-debug-make: $(CLANG_LLVM_DEBUG_ARCHIVE) | stamps
+	mkdir -p "$(S2E_BUILD)/llvm-debug"
+	tar -Jxf $< --transform s/$(CLANG_LLVM)/llvm-debug/
+	touch $@
 
-LLVM_CONFIGURE_FLAGS = -DLLVM_TARGETS_TO_BUILD="X86"        \
-                       -DLLVM_TARGET_ARCH="X86_64"          \
-                       -DLLVM_INCLUDE_EXAMPLES=Off          \
-                       -DLLVM_INCLUDE_DOCS=Off              \
-                       -DLLVM_INCLUDE_TESTS=On              \
-                       -DLLVM_ENABLE_RTTI=On                \
-                       -DLLVM_ENABLE_EH=On                  \
-                       -DLLVM_INCLUDE_BENCHMARKS=Off        \
-                       -DLLVM_BINUTILS_INCDIR=/usr/include  \
-                       -DCOMPILER_RT_BUILD_SANITIZERS=Off   \
-                       -DENABLE_ASSERTIONS=On               \
-                       -DCMAKE_C_COMPILER=$(CLANG_CC)       \
-                       -DCMAKE_CXX_COMPILER=$(CLANG_CXX)    \
-                       -DCMAKE_C_FLAGS="$(CFLAGS_ARCH)"     \
-                       -G "Unix Makefiles"
-
-stamps/llvm-debug-configure: stamps/clang-binary $(LLVM_SRC_DIR)
-stamps/llvm-debug-configure: CONFIGURE_COMMAND = cmake $(LLVM_CONFIGURE_FLAGS)         \
-                                                 -DCMAKE_BUILD_TYPE=Debug              \
-                                                 -DCMAKE_CXX_FLAGS="$(CXXFLAGS_DEBUG)" \
-                                                 $(LLVM_BUILD)/$(LLVM_SRC_DIR)
-
-stamps/llvm-release-configure: stamps/clang-binary $(LLVM_SRC_DIR)
-stamps/llvm-release-configure: CONFIGURE_COMMAND = cmake $(LLVM_CONFIGURE_FLAGS)           \
-                                                   -DCMAKE_BUILD_TYPE=Release              \
-                                                   -DCMAKE_CXX_FLAGS="$(CXXFLAGS_RELEASE)" \
-                                                   $(LLVM_BUILD)/$(LLVM_SRC_DIR)
-
-stamps/llvm-debug-make: stamps/llvm-debug-configure
-
-stamps/llvm-release-make: stamps/llvm-release-configure
-
-stamps/llvm-release-install: stamps/llvm-release-make
-	cp $(S2E_BUILD)/llvm-release/lib/LLVMgold.so $(S2E_PREFIX)/lib
-
-else
-stamps/llvm-release-make:
-	echo "Won't build"
-stamps/llvm-debug-make:
-	echo "Won't build"
-stamps/llvm-release-install:
-	echo "Won't build"
-endif
+CLANG_CC=$(S2E_BUILD)/llvm-release/bin/clang
+CLANG_CXX=$(S2E_BUILD)/llvm-release/bin/clang++
+CLANG_LIB=$(S2E_BUILD)/llvm-release/lib
 
 ########
 # SOCI #
@@ -363,7 +306,7 @@ SOCI_CONFIGURE_FLAGS = -DCMAKE_INSTALL_PREFIX=$(S2E_PREFIX) \
                        -DCMAKE_C_FLAGS="-fPIC"              \
                        -G "Unix Makefiles"
 
-stamps/soci-configure: stamps/clang-binary $(SOCI_BUILD_DIR)
+stamps/soci-configure: stamps/llvm-release-make $(SOCI_BUILD_DIR)
 stamps/soci-configure: CONFIGURE_COMMAND = cmake $(SOCI_CONFIGURE_FLAGS)    \
                                            $(S2E_BUILD)/$(SOCI_SRC_DIR)
 
@@ -385,7 +328,7 @@ Z3_CONFIGURE_FLAGS = -DCMAKE_INSTALL_PREFIX=$(S2E_PREFIX)               \
                      -DUSE_OPENMP=Off                                   \
                      -G "Unix Makefiles"
 
-stamps/z3-configure: stamps/clang-binary $(Z3_BUILD_DIR)
+stamps/z3-configure: stamps/llvm-release-make $(Z3_BUILD_DIR)
 	cd $(Z3_SRC_DIR) &&                                         \
 	python3 contrib/cmake/bootstrap.py create
 	cd $(Z3_BUILD_DIR) &&                                       \
@@ -431,7 +374,7 @@ CAPSTONE_CONFIGURE_FLAGS = -DCMAKE_INSTALL_PREFIX=$(S2E_PREFIX)         \
                      -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer -fPIC"  \
                      -G "Unix Makefiles"
 
-stamps/capstone-configure: stamps/clang-binary $(CAPSTONE_BUILD_DIR)
+stamps/capstone-configure: stamps/llvm-release-make $(CAPSTONE_BUILD_DIR)
 	cd $(CAPSTONE_BUILD_DIR) &&                                         \
 	cmake $(CAPSTONE_CONFIGURE_FLAGS) $(S2E_BUILD)/$(CAPSTONE_SRC_DIR)
 	touch $@
@@ -445,7 +388,7 @@ stamps/capstone-make: stamps/capstone-configure
 # libdwarf #
 ############
 
-stamps/libdwarf-configure: stamps/clang-binary $(LIBDWARF_BUILD_DIR)
+stamps/libdwarf-configure: stamps/llvm-release-make $(LIBDWARF_BUILD_DIR)
 	cd $(LIBDWARF_BUILD_DIR) &&                                         \
 	CC=$(CLANG_CC) CXX=$(CLANG_CXX) $(S2E_BUILD)/$(LIBDWARF_SRC_DIR)/configure --prefix=$(S2E_PREFIX)
 	touch $@
@@ -466,7 +409,7 @@ RAPIDJSON_CONFIGURE_FLAGS = -DCMAKE_INSTALL_PREFIX=$(S2E_PREFIX)                
                             -DRAPIDJSON_BUILD_TESTS=OFF
 
 
-stamps/rapidjson-configure: stamps/clang-binary $(RAPIDJSON_BUILD_DIR)
+stamps/rapidjson-configure: stamps/llvm-release-make $(RAPIDJSON_BUILD_DIR)
 	cd $(RAPIDJSON_BUILD_DIR) &&                                         \
 	cmake $(RAPIDJSON_CONFIGURE_FLAGS) $(S2E_BUILD)/$(RAPIDJSON_SRC_DIR)
 	touch $@
@@ -479,7 +422,7 @@ stamps/rapidjson-make: stamps/rapidjson-configure
 # protobuf #
 ############
 
-stamps/protobuf-configure: stamps/clang-binary $(PROTOBUF_BUILD_DIR)
+stamps/protobuf-configure: stamps/llvm-release-make $(PROTOBUF_BUILD_DIR)
 	cd $(PROTOBUF_BUILD_DIR) &&                                         \
 	CC=$(CLANG_CC) CXX=$(CLANG_CXX) CXXFLAGS=-fPIC CFLAGS=-fPIC $(S2E_BUILD)/$(PROTOBUF_SRC_DIR)/configure --prefix=$(S2E_PREFIX)
 	touch $@
@@ -506,7 +449,7 @@ stamps/lua-make: $(LUA_DIR)
 # GTest #
 #########
 
-stamps/gtest-release-configure: stamps/clang-binary $(GTEST_BUILD_DIR)
+stamps/gtest-release-configure: stamps/llvm-release-make $(GTEST_BUILD_DIR)
 	cd $(GTEST_BUILD_DIR) && cmake -DCMAKE_C_COMPILER=$(CLANG_CC) \
 	-DCMAKE_CXX_COMPILER=$(CLANG_CXX)  \
 	$(GTEST_SRC_DIR)
@@ -609,7 +552,7 @@ LIBFSIGCXX_COMMON_FLAGS = -DCMAKE_MODULE_PATH=$(S2E_SRC)/cmake  \
                           -DCMAKE_C_FLAGS="$(CFLAGS_ARCH)"      \
                           -G "Unix Makefiles"
 
-stamps/libfsigc++-debug-configure: stamps/clang-binary $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libfsigc++)
+stamps/libfsigc++-debug-configure: stamps/llvm-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libfsigc++)
 
 stamps/libfsigc++-debug-configure: CONFIGURE_COMMAND = cmake $(LIBFSIGCXX_COMMON_FLAGS) \
                                                        -DCMAKE_BUILD_TYPE=Debug         \
@@ -617,7 +560,7 @@ stamps/libfsigc++-debug-configure: CONFIGURE_COMMAND = cmake $(LIBFSIGCXX_COMMON
                                                        $(S2E_SRC)/libfsigc++
 
 
-stamps/libfsigc++-release-configure: stamps/clang-binary $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libfsigc++)
+stamps/libfsigc++-release-configure: stamps/llvm-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libfsigc++)
 
 stamps/libfsigc++-release-configure: CONFIGURE_COMMAND = cmake $(LIBFSIGCXX_COMMON_FLAGS)   \
                                      -DCMAKE_BUILD_TYPE=$(RELEASE_BUILD_TYPE)               \
@@ -638,7 +581,7 @@ LIBQ_COMMON_FLAGS = -DCMAKE_MODULE_PATH=$(S2E_SRC)/cmake    \
                     -DCMAKE_C_FLAGS="$(CFLAGS_ARCH)"        \
                     -G "Unix Makefiles"
 
-stamps/libq-debug-configure: stamps/clang-binary $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libq)
+stamps/libq-debug-configure: stamps/llvm-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libq)
 
 stamps/libq-debug-configure: CONFIGURE_COMMAND = cmake $(LIBQ_COMMON_FLAGS) \
                                                  -DCMAKE_BUILD_TYPE=Debug   \
@@ -646,7 +589,7 @@ stamps/libq-debug-configure: CONFIGURE_COMMAND = cmake $(LIBQ_COMMON_FLAGS) \
                                                  $(S2E_SRC)/libq
 
 
-stamps/libq-release-configure: stamps/clang-binary $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libq)
+stamps/libq-release-configure: stamps/llvm-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libq)
 
 stamps/libq-release-configure: CONFIGURE_COMMAND = cmake $(LIBQ_COMMON_FLAGS)                 \
                                                    -DCMAKE_BUILD_TYPE=$(RELEASE_BUILD_TYPE)   \
@@ -667,7 +610,7 @@ LIBCOROUTINE_COMMON_FLAGS = -DCMAKE_MODULE_PATH=$(S2E_SRC)/cmake    \
                             -DCMAKE_C_FLAGS="$(CFLAGS_ARCH)"        \
                             -G "Unix Makefiles"
 
-stamps/libcoroutine-debug-configure: stamps/clang-binary $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libcoroutine)
+stamps/libcoroutine-debug-configure: stamps/llvm-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libcoroutine)
 
 stamps/libcoroutine-debug-configure: CONFIGURE_COMMAND = cmake $(LIBCOROUTINE_COMMON_FLAGS)    \
                                                          -DCMAKE_BUILD_TYPE=Debug              \
@@ -675,7 +618,7 @@ stamps/libcoroutine-debug-configure: CONFIGURE_COMMAND = cmake $(LIBCOROUTINE_CO
                                                          $(S2E_SRC)/libcoroutine
 
 
-stamps/libcoroutine-release-configure: stamps/clang-binary $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libcoroutine)
+stamps/libcoroutine-release-configure: stamps/llvm-release-make $(call FIND_CONFIG_SOURCE,$(S2E_SRC)/libcoroutine)
 
 stamps/libcoroutine-release-configure: CONFIGURE_COMMAND = cmake $(LIBCOROUTINE_COMMON_FLAGS)        \
                                                            -DCMAKE_BUILD_TYPE=$(RELEASE_BUILD_TYPE)  \

--- a/libs2e/src/CMakeLists.txt
+++ b/libs2e/src/CMakeLists.txt
@@ -86,4 +86,4 @@ set(COMMON_FLAGS "${COMMON_FLAGS} -Wall -fPIC -fno-strict-aliasing -fexceptions"
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WERROR_FLAGS} ${COMMON_FLAGS} -std=c++14")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WERROR_FLAGS} ${COMMON_FLAGS}")
-set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/mapfile")
+set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--as-needed -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/mapfile")

--- a/libs2ecore/src/S2E.cpp
+++ b/libs2ecore/src/S2E.cpp
@@ -34,7 +34,6 @@
 #include <s2e/S2EExecutor.h>
 #include <s2e/Utils.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>

--- a/libs2ecore/src/S2EExecutor.cpp
+++ b/libs2ecore/src/S2EExecutor.cpp
@@ -47,7 +47,6 @@
 #include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/Process.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
 

--- a/libs2eplugins/src/s2e/Plugins/Analyzers/CFIChecker.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Analyzers/CFIChecker.cpp
@@ -197,45 +197,39 @@ struct CFIViolation {
         s2e_trace::PbTraceCfiViolation v;
         v.set_type(isReturnViolation ? s2e_trace::RETURN_VIOLATION : s2e_trace::CALL_VIOLATION);
 
-        s2e_trace::PbTraceViolationPcInfo s;
-        s.set_pc(sourcePc);
+        auto s = new s2e_trace::PbTraceViolationPcInfo();
+        s->set_pc(sourcePc);
         if (source) {
             uint64_t native = 0;
             source->ToNativeBase(sourcePc, native);
-            s.set_module_pc(native);
-            s.set_module_path(source->Path);
+            s->set_module_pc(native);
+            s->set_module_path(source->Path);
         }
-        v.set_allocated_source(&s);
+        v.set_allocated_source(s);
 
-        s2e_trace::PbTraceViolationPcInfo d;
-        d.set_pc(destPc);
+        auto d = new s2e_trace::PbTraceViolationPcInfo();
+        d->set_pc(destPc);
         if (dest) {
             uint64_t native = 0;
             dest->ToNativeBase(destPc, native);
-            d.set_module_pc(native);
-            d.set_module_path(dest->Path);
+            d->set_module_pc(native);
+            d->set_module_path(dest->Path);
         }
-        v.set_allocated_destination(&d);
+        v.set_allocated_destination(d);
 
-        s2e_trace::PbTraceViolationPcInfo e;
         if (expectedDestPc) {
-            e.set_pc(expectedDestPc);
+            auto e = new s2e_trace::PbTraceViolationPcInfo();
+            e->set_pc(expectedDestPc);
             if (expectedDest) {
                 uint64_t native = 0;
                 expectedDest->ToNativeBase(expectedDestPc, native);
-                e.set_module_pc(native);
-                e.set_module_path(expectedDest->Path);
+                e->set_module_pc(native);
+                e->set_module_path(expectedDest->Path);
             }
-            v.set_allocated_expected_destination(&e);
+            v.set_allocated_expected_destination(e);
         }
 
         tracer->writeData(state, v, s2e_trace::TRACE_CFI_VIOLATION);
-
-        if (expectedDestPc) {
-            v.release_expected_destination();
-        }
-        v.release_destination();
-        v.release_source();
     }
 };
 

--- a/libs2eplugins/src/s2e/Plugins/Core/HostFiles.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Core/HostFiles.cpp
@@ -36,7 +36,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/Path.h>
 

--- a/libs2eplugins/src/s2e/Plugins/Core/Vmi.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Core/Vmi.cpp
@@ -27,7 +27,6 @@
 #include <s2e/cpu.h>
 
 #include <iostream>
-#include <llvm/Config/config.h>
 #include <llvm/Support/FileSystem.h>
 
 #include "Vmi.h"

--- a/llvm/Dockerfile
+++ b/llvm/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright (C) 2017-2023, Cyberhaven
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Generates an LLVM + Clang build that can be later used to build S2E.
+
+# Use an older distribution for maximum compatibility.
+FROM ubuntu:18.04
+
+# Install build dependencies
+RUN dpkg --add-architecture i386 && apt-get update &&                       \
+    apt-get -y install ca-certificates build-essential curl wget texinfo flex bison  \
+    python3-dev python3-venv python3-distro lsb-release \
+    libdwarf-dev libelf-dev libelf-dev:i386 \
+    zlib1g-dev nasm pkg-config                 \
+    libpq-dev libc6-dev-i386 binutils-dev                  \
+    libbsd-dev \
+    libglib2.0-dev libglib2.0-dev:i386 python3-docutils libpng-dev          \
+    gcc-multilib g++-multilib libgomp1 unzip pigz
+
+# CMake 3.13.4 or higher is required to build LLVM 14 from source.
+# Ubuntu 18.04 comes with cmake 3.10.2
+# Install the latest cmake (as of this writing)
+RUN wget -O cmake.sh https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-Linux-x86_64.sh && \
+    sh ./cmake.sh --prefix=/usr/local --skip-license
+
+RUN mkdir llvm llvm-build
+COPY Makefile determine_clang_binary_suffix.py llvm/
+
+RUN cd llvm-build && make -f ../llvm/Makefile LLVM_PREFIX=/opt/llvm release debug

--- a/llvm/Makefile
+++ b/llvm/Makefile
@@ -1,0 +1,213 @@
+# Copyright (C) 2014-2023 Cyberhaven
+# Copyright (C) 2010-2014 Dependable Systems Laboratory, EPFL
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Environment variables:
+#
+#  PARALLEL=no
+#      Turn off build parallelization.
+#
+#  BUILD_ARCH=corei7, etc...
+#      Overrides the default clang -march settings.
+#      Useful to build LLVM in VirtualBox or in other VMs that do not support
+#      some advanced instruction sets.
+#
+
+#############
+# Variables #
+#############
+
+# LLVM variables
+MAKEFILE_PATH?=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+LLVM_PREFIX?=$(CURDIR)/opt
+LLVM_BUILD:=$(CURDIR)
+
+# Either choose Release or RelWithDebInfo
+RELEASE_BUILD_TYPE=RelWithDebInfo
+
+BUILD_ARCH?=x86-64
+
+CFLAGS_ARCH:=-march=$(BUILD_ARCH)
+CXXFLAGS_ARCH:=-march=$(BUILD_ARCH)
+
+CXXFLAGS_DEBUG:=$(CXXFLAGS_ARCH)
+CXXFLAGS_RELEASE:=$(CXXFLAGS_ARCH)
+
+SED:=sed
+
+# Set the number of parallel build jobs
+OS:=$(shell uname)
+ifeq ($(PARALLEL), no)
+JOBS:=1
+else ifeq ($(OS),Darwin)
+JOBS:=$(patsubst hw.ncpu:%,%,$(shell sysctl hw.ncpu))
+SED:=gsed
+PLATFORM:=darwin
+else ifeq ($(OS),Linux)
+JOBS:=$(shell grep -c ^processor /proc/cpuinfo)
+PLATFORM:=linux
+endif
+
+MAKE:=make -j$(JOBS)
+
+# LLVM variables
+LLVM_BUILD?=$(LLVM_BUILD)
+ifeq ($(LLVM_BUILD),$(LLVM_BUILD))
+LLVM_DIRS=llvm-release llvm-debug
+endif
+
+# More recent point releases don't have the Ubuntu binaries yet, so stick with 14.0.0.
+LLVM_VERSION=14.0.0
+LLVM_SRC=llvm-$(LLVM_VERSION).src.tar.xz
+LLVM_SRC_DIR=llvm-$(LLVM_VERSION).src
+LLVM_SRC_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VERSION)/
+
+# The Python script should only return a single word - the suffix of the Clang
+# binary to download. If an error message is printed to stderr, the Makefile
+# error will be triggered.
+CLANG_BINARY_SUFFIX=$(shell $(MAKEFILE_PATH)/determine_clang_binary_suffix.py 2>&1)
+ifneq ($(words $(CLANG_BINARY_SUFFIX)), 1)
+$(error "Failed to determine Clang binary to download: $(CLANG_BINARY_SUFFIX)")
+endif
+
+CLANG_BINARY_DIR=clang+llvm-$(LLVM_VERSION)-$(CLANG_BINARY_SUFFIX)
+CLANG_BINARY=$(CLANG_BINARY_DIR).tar.xz
+
+CLANG_SRC=clang-$(LLVM_VERSION).src.tar.xz
+CLANG_SRC_DIR=clang-$(LLVM_VERSION).src
+CLANG_DEST_DIR=$(LLVM_SRC_DIR)/tools/clang
+
+COMPILER_RT_SRC=compiler-rt-$(LLVM_VERSION).src.tar.xz
+COMPILER_RT_SRC_DIR=compiler-rt-$(LLVM_VERSION).src
+COMPILER_RT_DEST_DIR=$(LLVM_SRC_DIR)/projects/compiler-rt
+
+
+###########
+# Targets #
+###########
+
+release: $(LLVM_PREFIX)/release/$(CLANG_BINARY_DIR).tar.xz
+debug: $(LLVM_PREFIX)/debug/$(CLANG_BINARY_DIR).tar.xz
+
+ALWAYS:
+
+$(LLVM_DIRS) stamps:
+	mkdir -p $@
+
+stamps/%-configure: | % stamps
+	cd $* && $(CONFIGURE_COMMAND)
+	touch $@
+
+stamps/%-make:
+	$(MAKE) -C $* $(BUILD_OPTS)
+	touch $@
+
+#############
+# Downloads #
+#############
+
+define DOWNLOAD
+curl -f -L "$1" -o "$2"
+endef
+
+
+# Download LLVM
+$(LLVM_SRC) $(CLANG_SRC) $(COMPILER_RT_SRC) $(CLANG_BINARY):
+	$(call DOWNLOAD,$(LLVM_SRC_URL)/$@,$@)
+
+
+.INTERMEDIATE: $(CLANG_SRC_DIR) $(COMPILER_RT_SRC_DIR) $(CLANG_BINARY_DIR)
+
+$(LLVM_SRC_DIR): $(LLVM_SRC) $(CLANG_SRC_DIR) $(COMPILER_RT_SRC_DIR)
+	tar -xmf $<
+	mv $(CLANG_SRC_DIR) $(CLANG_DEST_DIR)
+	mv $(COMPILER_RT_SRC_DIR) $(COMPILER_RT_DEST_DIR)
+
+$(CLANG_SRC_DIR): $(CLANG_SRC)
+	tar -xmf $<
+
+$(COMPILER_RT_SRC_DIR): $(COMPILER_RT_SRC)
+	tar -xmf $<
+
+
+########
+# LLVM #
+########
+
+stamps/clang-binary: $(CLANG_BINARY) | stamps
+	tar -xmf $<
+	mkdir -p $(LLVM_PREFIX)
+	cp -r $(CLANG_BINARY_DIR)/* $(LLVM_PREFIX)
+	rm -r $(CLANG_BINARY_DIR)/*
+	touch $@
+
+CLANG_CC = $(LLVM_PREFIX)/bin/clang
+CLANG_CXX = $(LLVM_PREFIX)/bin/clang++
+CLANG_LIB = $(LLVM_PREFIX)/lib
+
+LLVM_CONFIGURE_FLAGS = -DLLVM_TARGETS_TO_BUILD="X86"        \
+                       -DLLVM_TARGET_ARCH="X86_64"          \
+                       -DLLVM_INCLUDE_EXAMPLES=Off          \
+                       -DLLVM_INCLUDE_DOCS=Off              \
+                       -DLLVM_INCLUDE_TESTS=On              \
+                       -DLLVM_ENABLE_RTTI=On                \
+                       -DLLVM_ENABLE_EH=On                  \
+                       -DLLVM_INCLUDE_BENCHMARKS=Off        \
+                       -DLLVM_BINUTILS_INCDIR=/usr/include  \
+                       -DCOMPILER_RT_BUILD_SANITIZERS=Off   \
+                       -DENABLE_ASSERTIONS=On               \
+                       -DCMAKE_C_COMPILER=$(CLANG_CC)       \
+                       -DCMAKE_CXX_COMPILER=$(CLANG_CXX)    \
+                       -DCMAKE_C_FLAGS="$(CFLAGS_ARCH)"     \
+                       -G "Unix Makefiles"
+
+stamps/llvm-debug-configure: stamps/clang-binary $(LLVM_SRC_DIR)
+stamps/llvm-debug-configure: CONFIGURE_COMMAND = cmake $(LLVM_CONFIGURE_FLAGS)         \
+                                                 -DCMAKE_BUILD_TYPE=Debug              \
+                                                 -DCMAKE_CXX_FLAGS="$(CXXFLAGS_DEBUG)" \
+												 -DCMAKE_INSTALL_PREFIX="$(LLVM_PREFIX)/debug/$(CLANG_BINARY_DIR)" \
+                                                 $(LLVM_BUILD)/$(LLVM_SRC_DIR)
+
+stamps/llvm-release-configure: stamps/clang-binary $(LLVM_SRC_DIR)
+stamps/llvm-release-configure: CONFIGURE_COMMAND = cmake $(LLVM_CONFIGURE_FLAGS)           \
+                                                   -DCMAKE_BUILD_TYPE=$(RELEASE_BUILD_TYPE)  \
+                                                   -DCMAKE_CXX_FLAGS="$(CXXFLAGS_RELEASE)" \
+												   -DCMAKE_INSTALL_PREFIX="$(LLVM_PREFIX)/release/$(CLANG_BINARY_DIR)" \
+                                                   $(LLVM_BUILD)/$(LLVM_SRC_DIR)
+
+stamps/llvm-debug-make: stamps/llvm-debug-configure
+
+stamps/llvm-release-make: stamps/llvm-release-configure
+
+stamps/llvm-release-install: stamps/llvm-release-make
+	cd $(LLVM_BUILD)/llvm-release && make install
+	-cd $(LLVM_PREFIX)/release/$(CLANG_BINARY_DIR)/bin && strip *
+	cp $(LLVM_BUILD)/llvm-release/lib/LLVMgold.so $(LLVM_PREFIX)/release/$(CLANG_BINARY_DIR)/lib
+
+stamps/llvm-debug-install: stamps/llvm-debug-make
+	cd $(LLVM_BUILD)/llvm-debug && make install
+	-cd $(LLVM_PREFIX)/debug/$(CLANG_BINARY_DIR)/bin && strip *
+	cp $(LLVM_BUILD)/llvm-debug/lib/LLVMgold.so $(LLVM_PREFIX)/debug/$(CLANG_BINARY_DIR)/lib
+
+$(LLVM_PREFIX)/release/$(CLANG_BINARY_DIR).tar.xz: stamps/llvm-release-install
+	cd $(LLVM_PREFIX)/release && tar -I "xz -T 0" -cf "$(shell basename $@)" $(CLANG_BINARY_DIR)
+
+$(LLVM_PREFIX)/debug/$(CLANG_BINARY_DIR).tar.xz: stamps/llvm-debug-install
+	cd $(LLVM_PREFIX)/debug && tar -I "xz -T 0" -cf "$(shell basename $@)" $(CLANG_BINARY_DIR)

--- a/llvm/build.sh
+++ b/llvm/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (C) 2023 Vitaly Chipounov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -xe
+
+IMAGE=s2e-llvm-build
+BUILD_NAME=clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04
+
+docker build -t $IMAGE .
+
+./extract-docker.sh $IMAGE /opt/llvm/debug/$BUILD_NAME.tar.xz .
+mv $BUILD_NAME.tar.xz $BUILD_NAME-debug.tar.xz
+./extract-docker.sh $IMAGE /opt/llvm/release/$BUILD_NAME.tar.xz .
+mv $BUILD_NAME.tar.xz $BUILD_NAME-release.tar.xz

--- a/llvm/determine_clang_binary_suffix.py
+++ b/llvm/determine_clang_binary_suffix.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Adrian Herrera
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Inspects the current operating system and determines which Clang binary to
+download. If a valid version is found, the suffix of the file to download is
+printed to stdout. Otherwise an error message is printed to stderr.
+
+Note: This script is only really meant to be used by the S2E Makefile. It has
+no real use outside of this.
+"""
+
+import distro
+import sys
+
+
+# Supported operating systems for Clang binary downloads
+SUPPORTED_OS = ('ubuntu', 'debian')
+
+
+def eprint(*args, **kwargs):
+    """Print to stderr and exit."""
+    print(*args, file=sys.stderr, **kwargs)
+    sys.exit(1)
+
+
+def _get_debian_version(version_string):
+    """
+    Determine the Clang binary to download from the version string returned by
+    ``distro.linux_distribution``.
+    """
+    version = int(version_string)
+
+    if version >= 8:
+        return 'x86_64-linux-gnu-ubuntu-18.04'
+    else:
+        return None
+
+
+def _get_ubuntu_version(version_string):
+    """
+    Determine the Clang binary to downoad from the version string returned by
+    ``distro.linux_distribution``.
+    """
+    major_version, minor_version = list(map(int, version_string.split('.')))
+
+    if major_version == 14 and minor_version >= 4:
+        return 'x86_64-linux-gnu-ubuntu-14.04',
+    elif major_version == 15:
+        return 'x86_64-linux-gnu-ubuntu-14.04',
+    elif major_version == 16 and minor_version >= 4:
+        return 'x86_64-linux-gnu-ubuntu-16.04',
+    elif major_version == 18:
+        return 'x86_64-linux-gnu-ubuntu-18.04',
+    elif major_version == 20:
+        return 'x86_64-linux-gnu-ubuntu-18.04',
+    elif major_version == 22:
+        return 'x86_64-linux-gnu-ubuntu-18.04',
+    else:
+        return None
+
+
+def main():
+    """The main function."""
+    name = distro.id()
+    version = distro.version()
+
+    clang_ver_to_download = None
+
+    if name.lower() == 'darwin':
+        clang_ver_to_download = 'x86_64-darwin-apple'
+    elif name.lower() == 'debian':
+        clang_ver_to_download = _get_debian_version(version)
+    elif name.lower() == 'ubuntu':
+        clang_ver_to_download = _get_ubuntu_version(version)
+    else:
+        eprint('Linux distro %s is not supported' % name)
+
+    if clang_ver_to_download:
+        print('%s' % clang_ver_to_download)
+    else:
+        eprint('%s %s is not supported' % (distro, version))
+
+
+if __name__ == '__main__':
+    main()

--- a/llvm/extract-docker.sh
+++ b/llvm/extract-docker.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (C) 2017, Cyberhaven
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <docker_image> <docker_dir_or_file> <output_dir>"
+    exit 1
+fi
+
+docker_image=$1
+docker_dir=$2
+output_dir=$(mkdir -p $3 && cd $3 && pwd)
+
+docker_container=`docker run -d "$docker_image" sleep 1000`
+docker cp "${docker_container}:$docker_dir" "$output_dir" || true
+docker kill "$docker_container" >/dev/null || true
+docker rm "$docker_container" >/dev/null


### PR DESCRIPTION
This PR splits LLVM building into a separate makefile.
The main makefile fetches pre-compiled clang/llvm binaries from github release pages.