### PR TITLE
Update s2e.asm to fix stack imbalance

### DIFF
--- a/guest/common/include/s2e/opcodes.h
+++ b/guest/common/include/s2e/opcodes.h
@@ -93,7 +93,6 @@ extern "C" {
 #define BASE_S2E_CLEAR_TEMPS    0x53
 #define BASE_S2E_FORK_COUNT     0x54
 #define BASE_S2E_FLUSH_TBS      0x55
-#define BASE_S2E_SET_LIBCPU_LOG_LEVEL 0x56
 
 // Maximum S2E opcode allowed
 #define BASE_S2E_MAX_OPCODE     0x70

--- a/guest/windows/libcommon/include/s2e/s2e.h
+++ b/guest/windows/libcommon/include/s2e/s2e.h
@@ -94,8 +94,6 @@ UINT32 NTAPI S2EWriteMemory(PVOID Destination, PVOID Source, DWORD Count);
 VOID NTAPI S2EDisableAllApicInterrupts(VOID);
 VOID NTAPI S2EEnableAllApicInterrupts(VOID);
 
-VOID NTAPI S2ESetCpuLogLevel(UINT32 LogLevel);
-
 VOID NTAPI S2EMakeSymbolic(PVOID Buffer, UINT32 Size, PCSTR Name);
 INT NTAPI S2ESymbolicInt(PCSTR Name, INT InitialValue);
 UINT8 NTAPI S2ESymbolicChar(PCSTR Name, UINT8 InitialValue);

--- a/guest/windows/libcommon/src/amd64/s2e.asm
+++ b/guest/windows/libcommon/src/amd64/s2e.asm
@@ -424,15 +424,4 @@ S2EReturnHook64 proc frame
     ret
 S2EReturnHook64 endp
 
-;RCX, RDX, R8, R9
-public S2ESetCpuLogLevel
-S2ESetCpuLogLevel proc frame ; _Level: dword
-    .endprolog
-    mov rax, rcx; _Level
-    db 0fh, 3fh
-    db 00h, 56h, 00h, 00h
-    db 00h, 00h, 00h, 00h
-    ret
-S2ESetCpuLogLevel endp
-
 end

--- a/guest/windows/libcommon/src/i386/s2e.asm
+++ b/guest/windows/libcommon/src/i386/s2e.asm
@@ -315,15 +315,5 @@ S2EEnableAllApicInterrupts proc near
     ret
 S2EEnableAllApicInterrupts endp
 
-public S2ESetCpuLogLevel
-S2ESetCpuLogLevel proc near _Level: dword
-    mov eax, _Level
-    db 0fh, 3fh
-    db 00h, 56h, 00h, 00h
-    db 00h, 00h, 00h, 00h
-    ret 08h
-S2ESetCpuLogLevel endp
-
-
 end
 

--- a/guest/windows/libs2e/libs2e.def
+++ b/guest/windows/libs2e/libs2e.def
@@ -17,7 +17,6 @@ EXPORTS
     S2EPrintExpression
     S2EKillState
     S2EWriteMemory
-    S2ESetCpuLogLevel
     S2EMakeSymbolic
     S2ESymbolicInt
     S2ESymbolicChar

--- a/libs2eplugins/src/s2e/Plugins/Core/BaseInstructions.cpp
+++ b/libs2eplugins/src/s2e/Plugins/Core/BaseInstructions.cpp
@@ -942,11 +942,6 @@ void BaseInstructions::handleBuiltInOps(S2EExecutionState *state, uint64_t opcod
             se_tb_safe_flush();
         } break;
 
-        case BASE_S2E_SET_LIBCPU_LOG_LEVEL: {
-            loglevel = (int) state->regs()->read<uint64_t>(CPU_OFFSET(regs[R_EAX]));
-            getInfoStream(state) << "Set libcpu loglevel to " << hexval(loglevel) << "\n";
-        } break;
-
         default:
             getWarningsStream(state) << "BaseInstructions: Invalid built-in opcode " << hexval(opcode) << '\n';
             break;


### PR DESCRIPTION
Hello there, I recently discovered that the i386 asm stub for `S2ESetCpuLogLevel` leads to an unbalanced stack. I figure I should bring it to your attention, although I'm not sure if this function is still actively being used. Thank you.