### PR TITLE
fix: error: '_Noreturn' does not name a type

### DIFF
--- a/libtcg/include/tcg/utils/osdep.h
+++ b/libtcg/include/tcg/utils/osdep.h
@@ -143,7 +143,7 @@ static inline void flush_idcache_range(uintptr_t rx, uintptr_t rw, size_t len) {
 }
 
 #define LIBTCG_ERROR(X) __attribute__((error(X)))
-extern _Noreturn void LIBTCG_ERROR("code path is reachable") qemu_build_not_reached_always(void);
+NORETURN extern void LIBTCG_ERROR("code path is reachable") qemu_build_not_reached_always(void);
 
 static inline void qemu_thread_jit_write(void) {
 }


### PR DESCRIPTION
_Noreturn fails to compile with gcc (i know, i should use clang)

make LIBTCG_ERROR consistent with QEMU_ERROR

```cc
NORETURN extern void QEMU_ERROR("code path is reachable") qemu_build_not_reached_always(void);
NORETURN extern void LIBTCG_ERROR("code path is reachable") qemu_build_not_reached_always(void);
```