### PR TITLE
libs2e: bugfix handling of S2E_MAX_PROCESS env

### DIFF
--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -262,7 +262,7 @@ void S2EKVM::init(void) {
 
     int max_processes = 1;
     const char *max_processes_str = getenv("S2E_MAX_PROCESSES");
-    if (max_processes) {
+    if (max_processes_str) {
         max_processes = strtol(max_processes_str, NULL, 0);
     }
 


### PR DESCRIPTION
strtol was always called even if S2E_MAX_PROCESS was not defined causing the preloading of the library to fail due to NULL ptr returned from getenv and passed straight in strtol. Fixed by checking for the correct variable.