### PR TITLE
guest/linux/cgcload: fixed implicit func decls

### DIFF
--- a/guest/linux/cgcload/loader.c
+++ b/guest/linux/cgcload/loader.c
@@ -47,6 +47,7 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/prctl.h>
+#include <unistd.h>
 
 #include "cgc.h"
 #include "loader.h"

--- a/guest/linux/povtest/CMakeLists.txt
+++ b/guest/linux/povtest/CMakeLists.txt
@@ -22,6 +22,6 @@
 
 add_executable(povtest main.c)
 
-target_link_libraries(povtest pov cgc)
+target_link_libraries(povtest pov cgc pthread)
 
 install(TARGETS povtest RUNTIME DESTINATION .)


### PR DESCRIPTION
Fixed implicit declaration of functions of `read, write, close`.