### PR TITLE
Added support for QEMU 10.2

### DIFF
--- a/guest/s2ebios/tests/selfmod.c
+++ b/guest/s2ebios/tests/selfmod.c
@@ -45,14 +45,17 @@ void test_selfmod1() {
 
     void *exec_mem = (char *) 0x301bd;
 
-    memset(exec_mem, 0xf4, 0x1000); // Put hlt everywhere
+    memset(exec_mem, 0xc3, 0x1000); // Put ret everywhere
     memcpy(exec_mem, code, sizeof(code));
 
 #ifdef __x86_64__
+    s2e_message("Starting self-modifying code");
     __asm__ __volatile__("mov %0, %%rax\n"
                          "mov %%rax, %%rcx\n"
                          "mov $0x5b07e8d8c90406de, %%rdx\n"
                          "callq *%%rax\n" ::"a"(exec_mem));
+
+    s2e_message("Done self-modifying code");
 
 #else
     s2e_message("test_selfmod1 not supported in 32-bits mode");

--- a/guest/windows/.gitignore
+++ b/guest/windows/.gitignore
@@ -16,3 +16,5 @@ dist
 *PVS-Studio*
 *.idea
 *.TMP
+packages
+

--- a/guest/windows/driver/driver.vcxproj
+++ b/guest/windows/driver/driver.vcxproj
@@ -26,7 +26,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>driver</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/guest/windows/driver/driver.vcxproj
+++ b/guest/windows/driver/driver.vcxproj
@@ -26,7 +26,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>driver</RootNamespace>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/guest/windows/driver/driver.vcxproj
+++ b/guest/windows/driver/driver.vcxproj
@@ -106,6 +106,9 @@
       <ForcedIncludeFiles>$(KIT_SHARED_IncludePath)\warning.h;$(SolutionDir)\formatting.h</ForcedIncludeFiles>
       <SupportJustMyCode>false</SupportJustMyCode>
     </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA1</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Link>
@@ -115,6 +118,9 @@
     <ClCompile>
       <ForcedIncludeFiles>$(KIT_SHARED_IncludePath)\warning.h;$(SolutionDir)\formatting.h</ForcedIncludeFiles>
     </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA1</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
@@ -125,6 +131,9 @@
       <ForcedIncludeFiles>$(KIT_SHARED_IncludePath)\warning.h;$(SolutionDir)\formatting.h</ForcedIncludeFiles>
       <SupportJustMyCode>false</SupportJustMyCode>
     </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA1</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
@@ -134,6 +143,9 @@
     <ClCompile>
       <ForcedIncludeFiles>$(KIT_SHARED_IncludePath)\warning.h;$(SolutionDir)\formatting.h</ForcedIncludeFiles>
     </ClCompile>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA1</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />

--- a/guest/windows/driver/s2e.inf
+++ b/guest/windows/driver/s2e.inf
@@ -24,28 +24,30 @@
 
 [Version]
 Signature   = "$Windows NT$"
-Class       = "S2EGuestDriver"
+Class       = "ActivityMonitor"
 ClassGuid   = {b86dff51-a31e-4bac-b3cf-e8cfe75c9fc2}
 Provider    = %Cyberhaven%
 DriverVer   = 11/01/2018,2.0.0.0
 CatalogFile = s2e.cat
+PnpLockdown = 1
 
 
 [DestinationDirs]
 DefaultDestDir      = 12
 s2e.DriverFiles     = 12            ;%windir%\system32\drivers
 
-[DefaultInstall]
+[DefaultInstall.NTamd64]
 OptionDesc          = %ServiceDescription%
 CopyFiles           = s2e.DriverFiles
 
-[DefaultInstall.Services]
+[DefaultInstall.NTamd64.Services]
 AddService          = %ServiceName%,,s2e.Service
 
-[DefaultUninstall]
+[DefaultUninstall.NTamd64]
+LegacyUninstall     = 1
 DelFiles            =
 
-[DefaultUninstall.Services]
+[DefaultUninstall.NTamd64.Services]
 DelService = s2e,0x200      ;Ensure service is stopped before deleting
 
 [s2e.Service]
@@ -56,13 +58,13 @@ Dependencies     = "FltMgr"
 ServiceType      = 2                            ;SERVICE_FILE_SYSTEM_DRIVER
 StartType        = 3                            ;SERVICE_DEMAND_START
 ErrorControl     = 1                            ;SERVICE_ERROR_NORMAL
-LoadOrderGroup   = "FSFilter Content Screener"
+LoadOrderGroup   = "FSFilter Activity Monitor"
 AddReg           = s2e.AddRegistry
 
 [s2e.AddRegistry]
-HKR,"Instances","DefaultInstance",0x00000000,%DefaultInstance%
-HKR,"Instances\"%Instance1.Name%,"Altitude",0x00000000,%Instance1.Altitude%
-HKR,"Instances\"%Instance1.Name%,"Flags",0x00010001,%Instance1.Flags%
+HKR,"Parameters\Instances","DefaultInstance",0x00000000,%DefaultInstance%
+HKR,"Parameters\Instances\%Instance1.Name%","Altitude",0x00000000,%Instance1.Altitude%
+HKR,"Parameters\Instances\%Instance1.Name%","Flags",0x00010001,%Instance1.Flags%
 
 [s2e.DriverFiles]
 %DriverName%.sys

--- a/guest/windows/driver/src/crash.c
+++ b/guest/windows/driver/src/crash.c
@@ -202,11 +202,17 @@ VOID S2EBSODHook(
 {
     S2E_BSOD_CRASH Command;
     ULONG BufferNeeded = 0;
+    NTSTATUS Status = 0;
+
     LOG("Invoked S2EBSODHook\n");
 
     S2EDumpBackTrace();
 
-    InitializeCrashDumpHeader(&BufferNeeded);
+    Status = InitializeCrashDumpHeader(&BufferNeeded);
+    if (!NT_SUCCESS(Status)) {
+        LOG("InitializeCrashDumpHeader failed: %#x\n", Status);
+        S2EKillState(Status, "Could not generate crash dump header");
+    }
 
     if (IsWindows8OrAbove(&g_kernelStructs.Version)) {
         DecryptKdDataBlock();

--- a/guest/windows/driver/src/crash.c
+++ b/guest/windows/driver/src/crash.c
@@ -107,15 +107,17 @@ static NTSTATUS LfiKeInitializeCrashDumpHeader(
         return STATUS_NOT_SUPPORTED;
     }
 
-    if (IsWindows10_1909_OrAbove(&g_kernelStructs.Version)) {
+    if (IsWindows_2003SP1_OrAbove(&g_kernelStructs.Version)) {
+        auto ret = u._KeInitializeCrashDumpHeader(DumpType, Flags, Buffer, BufferSize, BufferNeeded);
+        LOG("_KeInitializeCrashDumpHeader returned %#x", ret);
+        return ret;
+    } else {
         if (!BufferSize) {
             *BufferNeeded = CRASH_DUMP_HEADER_SIZE;
             return STATUS_SUCCESS;
         }
 
         return u._KeInitializeCrashDumpHeader2(DumpType, Flags, Buffer, BufferSize);
-    } else {
-        return u._KeInitializeCrashDumpHeader(DumpType, Flags, Buffer, BufferSize, BufferNeeded);
     }
 }
 
@@ -131,28 +133,16 @@ NTSTATUS InitializeCrashDumpHeader(ULONG *BufferSize)
 
     /* Determine the size for the buffer */
     Status = LfiKeInitializeCrashDumpHeader(
-        1 /* DUMP_TYPE_FULL */, 0,
-        s_BugCheckHeaderBuffer, 0, &BufferNeeded);
+        1 /* DUMP_TYPE_FULL */, 0, s_BugCheckHeaderBuffer, CRASH_DUMP_HEADER_SIZE,
+                                            &BufferNeeded);
 
     if (!NT_SUCCESS(Status)) {
         return Status;
     }
 
-    if (BufferNeeded > 0) {
-        LOG("S2EBSODHook: crash dump header of size %#x\n", BufferNeeded);
-
-        if (BufferNeeded > CRASH_DUMP_HEADER_SIZE) {
-            LOG("S2EBSODHook: required buffer too big");
-            Status = STATUS_INSUFFICIENT_RESOURCES;
-        } else {
-            Status = LfiKeInitializeCrashDumpHeader(
-                1 /* DUMP_TYPE_FULL */, 0,
-                s_BugCheckHeaderBuffer, BufferNeeded, NULL);
-
-            if (!NT_SUCCESS(Status)) {
-                LOG("S2EBSODHook: failed to initialize crash dump header\n");
-            }
-        }
+    if (BufferNeeded > CRASH_DUMP_HEADER_SIZE) {
+        LOG("Requied buffer of size %#x is too large", BufferNeeded);
+        return STATUS_NOT_IMPLEMENTED;
     }
 
     *BufferSize = BufferNeeded;

--- a/guest/windows/driver/src/utils.h
+++ b/guest/windows/driver/src/utils.h
@@ -33,6 +33,27 @@ NTSTATUS S2EEncodeBackTraceForKnownModules(
 );
 
 
+static inline BOOLEAN IsWindows_2003SP1_OrAbove(_In_ const RTL_OSVERSIONINFOEXW *Version)
+{
+    if (Version->dwMajorVersion > 5) {
+        return TRUE;
+    }
+
+    if (Version->dwMajorVersion < 5) {
+        return FALSE;
+    }
+
+    if (Version->dwMinorVersion > 2) {
+        return TRUE;
+    }
+
+    if (Version->dwMinorVersion < 2) {
+        return FALSE;
+    }
+
+    return Version->wServicePackMajor >= 1;
+}
+
 static inline BOOLEAN IsWindows8OrAbove(_In_ const RTL_OSVERSIONINFOEXW *Version)
 {
     if (Version->dwMajorVersion > 6) {

--- a/guest/windows/libcommon/libcommon.vcxproj
+++ b/guest/windows/libcommon/libcommon.vcxproj
@@ -55,10 +55,10 @@
   <PropertyGroup Label="Globals">
     <RootNamespace>libcommon</RootNamespace>
     <VCTargetsPath Condition="'$(VCTargetsPath11)' != '' and '$(VisualStudioVersion)' == '11.0'">$(VCTargetsPath11)</VCTargetsPath>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="PropertySheets">
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/guest/windows/libcommon/libcommon.vcxproj
+++ b/guest/windows/libcommon/libcommon.vcxproj
@@ -55,7 +55,7 @@
   <PropertyGroup Label="Globals">
     <RootNamespace>libcommon</RootNamespace>
     <VCTargetsPath Condition="'$(VCTargetsPath11)' != '' and '$(VisualStudioVersion)' == '11.0'">$(VCTargetsPath11)</VCTargetsPath>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="PropertySheets">
     <PlatformToolset>v142</PlatformToolset>

--- a/guest/windows/libcommon_driver/libcommon_driver.vcxproj
+++ b/guest/windows/libcommon_driver/libcommon_driver.vcxproj
@@ -51,7 +51,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libcommon_driver</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/guest/windows/libcommon_driver/libcommon_driver.vcxproj
+++ b/guest/windows/libcommon_driver/libcommon_driver.vcxproj
@@ -51,6 +51,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libcommon_driver</RootNamespace>
     <DriverType>KMDF</DriverType>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/guest/windows/pdbparser/pdbparser.vcxproj
+++ b/guest/windows/pdbparser/pdbparser.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3A1CDCF6-4B82-41C0-83AF-55E1D915AB3E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/guest/windows/pdbparser/pdbparser.vcxproj
+++ b/guest/windows/pdbparser/pdbparser.vcxproj
@@ -21,27 +21,28 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3A1CDCF6-4B82-41C0-83AF-55E1D915AB3E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/guest/windows/s2e.sln
+++ b/guest/windows/s2e.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.1062
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.37206.5
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcommon", "libcommon\libcommon.vcxproj", "{F999B414-1B8E-4D40-9BF0-442560663847}"
 EndProject

--- a/klee/lib/Expr/Expr.cpp
+++ b/klee/lib/Expr/Expr.cpp
@@ -1455,33 +1455,119 @@ static ref<Expr> UltExpr_create(const ref<Expr> &l, const ref<Expr> &r) {
     Expr::Width t = l->getWidth();
     if (t == Expr::Bool) { // !l && r
         return AndExpr::create(Expr::createIsZero(l), r);
-    } else {
-        return UltExpr::alloc(l, r);
     }
+    // Ult l l => false
+    if (l == r) {
+        return ConstantExpr::create(0, Expr::Bool);
+    }
+    return UltExpr::alloc(l, r);
+}
+
+/// Returns the unsigned upper bound of \p e (the maximum value it can take),
+/// or UINT64_MAX if unknown. Handles constants, ZExt, and And-with-constant-mask.
+/// Recurses one level into ZExt to propagate inner And-mask bounds.
+static uint64_t get_unsigned_upper_bound(const ref<Expr> &e) {
+    if (e->getWidth() > 64) {
+        return UINT64_MAX;
+    }
+
+    if (const ConstantExpr *ce = dyn_cast<ConstantExpr>(e)) {
+        return ce->getZExtValue();
+    }
+
+    if (const ZExtExpr *ze = dyn_cast<ZExtExpr>(e)) {
+        unsigned innerW = ze->getSrc()->getWidth();
+        uint64_t widthMax = (innerW < 64) ? bitmask<uint64_t>(innerW) : UINT64_MAX;
+        // Recurse to pick up a tighter inner bound (e.g. And-mask inside ZExt).
+        uint64_t srcBound = get_unsigned_upper_bound(ze->getSrc());
+        return std::min(widthMax, srcBound);
+    }
+
+    if (const AndExpr *ae = dyn_cast<AndExpr>(e)) {
+        if (const ConstantExpr *mask = dyn_cast<ConstantExpr>(ae->getRight())) {
+            return mask->getZExtValue();
+        }
+        if (const ConstantExpr *mask = dyn_cast<ConstantExpr>(ae->getLeft())) {
+            return mask->getZExtValue();
+        }
+    }
+
+    return UINT64_MAX;
 }
 
 static ref<Expr> UleExpr_create(const ref<Expr> &l, const ref<Expr> &r) {
-    if (l->getWidth() == Expr::Bool) { // !(l && !r)
+    Expr::Width t = l->getWidth();
+
+    if (t == Expr::Bool) { // !(l && !r)
         return OrExpr::create(Expr::createIsZero(l), r);
-    } else {
-        return UleExpr::alloc(l, r);
     }
+
+    // Ule l l => true
+    if (l == r) {
+        return ConstantExpr::create(1, Expr::Bool);
+    }
+
+    // Patterns only reliable for widths that fit in uint64_t.
+    if (t <= 64) {
+        uint64_t maxVal = bitmask<uint64_t>(t); // UINT_t_MAX
+
+        // Pattern: Ule C (Add C (ZExt x)) => true when C + max(ZExt) doesn't overflow.
+        // Rationale: ZExt is non-negative, so the minimum of (Add C ZExt) is C (when
+        // ZExt == 0), making C <= C + ZExt trivially true as long as there is no wraparound.
+        if (const ConstantExpr *cl = dyn_cast<ConstantExpr>(l)) {
+            if (const AddExpr *addR = dyn_cast<AddExpr>(r)) {
+                if (const ConstantExpr *addConst = dyn_cast<ConstantExpr>(addR->getLeft())) {
+                    if (addConst->getAPValue() == cl->getAPValue()) {
+                        uint64_t clVal = cl->getZExtValue();
+                        uint64_t maxAdd = get_unsigned_upper_bound(addR->getRight());
+                        // No overflow: clVal + maxAdd <= maxVal
+                        if (maxAdd != UINT64_MAX && clVal <= maxVal - maxAdd) {
+                            return ConstantExpr::create(1, Expr::Bool);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Pattern: Ule (Add C (ZExt inner)) D => true when C + max(inner) <= D.
+        if (const ConstantExpr *cr = dyn_cast<ConstantExpr>(r)) {
+            if (const AddExpr *addL = dyn_cast<AddExpr>(l)) {
+                if (const ConstantExpr *addConst = dyn_cast<ConstantExpr>(addL->getLeft())) {
+                    uint64_t cVal = addConst->getZExtValue();
+                    uint64_t maxRhs = get_unsigned_upper_bound(addL->getRight());
+                    uint64_t dVal = cr->getZExtValue();
+                    // C + max(rhs) <= D, with overflow guard.
+                    if (maxRhs != UINT64_MAX && cVal <= maxVal - maxRhs && cVal + maxRhs <= dVal) {
+                        return ConstantExpr::create(1, Expr::Bool);
+                    }
+                }
+            }
+        }
+    }
+
+    return UleExpr::alloc(l, r);
 }
 
 static ref<Expr> SltExpr_create(const ref<Expr> &l, const ref<Expr> &r) {
     if (l->getWidth() == Expr::Bool) { // l && !r
         return AndExpr::create(l, Expr::createIsZero(r));
-    } else {
-        return SltExpr::alloc(l, r);
     }
+    // Slt l l => false
+    if (l == r) {
+        return ConstantExpr::create(0, Expr::Bool);
+    }
+    return SltExpr::alloc(l, r);
 }
 
 static ref<Expr> SleExpr_create(const ref<Expr> &l, const ref<Expr> &r) {
     if (l->getWidth() == Expr::Bool) { // !(!l && r)
         return OrExpr::create(l, Expr::createIsZero(r));
-    } else {
-        return SleExpr::alloc(l, r);
     }
+    // Sle l l => true
+    if (l == r) {
+        return ConstantExpr::create(1, Expr::Bool);
+    }
+    return SleExpr::alloc(l, r);
 }
 
 CMPCREATE_T(EqExpr, Eq, EqExpr, EqExpr_createPartial, EqExpr_createPartialR)

--- a/klee/lib/Expr/Expr.cpp
+++ b/klee/lib/Expr/Expr.cpp
@@ -33,6 +33,14 @@ cl::opt<bool> ConstArrayOpt("const-array-opt", cl::init(true),
 
 /***/
 
+const Expr::Width Expr::InvalidWidth;
+const Expr::Width Expr::Bool;
+const Expr::Width Expr::Int8;
+const Expr::Width Expr::Int16;
+const Expr::Width Expr::Int32;
+const Expr::Width Expr::Int64;
+const Expr::Width Expr::Int128;
+
 ///
 /// \brief Simplify the pattern that results from an unaligned read to memory.
 ///

--- a/klee/lib/Expr/Expr.cpp
+++ b/klee/lib/Expr/Expr.cpp
@@ -855,6 +855,22 @@ ref<Expr> ZExtExpr::create(const ref<Expr> &e, Width w) {
             return ZExtExpr::alloc(e, w);
         }
     } else {
+        // ZExt wN (Extract wM 0 (And wN X mask)) where mask == 2^M-1 => And wN X mask
+        // The And already zeros all bits above M, so the Extract+ZExt roundtrip is redundant.
+        if (const ExtractExpr *ext = dyn_cast<ExtractExpr>(e)) {
+            if (ext->getOffset() == 0) {
+                if (const AndExpr *andx = dyn_cast<AndExpr>(ext->getExpr())) {
+                    if (andx->getWidth() == w) {
+                        if (const ConstantExpr *mask = dyn_cast<ConstantExpr>(andx->getKid(1))) {
+                            if (kBits <= 64 && mask->getWidth() <= 64 &&
+                                mask->getZExtValue() == bitmask<uint64_t>(kBits)) {
+                                return ext->getExpr();
+                            }
+                        }
+                    }
+                }
+            }
+        }
         __LIFT_CONST_SELECT_1(e, w);
         return ZExtExpr::alloc(e, w);
     }
@@ -1018,6 +1034,13 @@ static ref<Expr> AndExpr_createPartial(Expr *l, const ref<ConstantExpr> &cr) {
         if (c2) {
             return AndExpr::create(a, AndExpr::create(c1, c2));
         }
+    } else if (const ZExtExpr *ze = dyn_cast<ZExtExpr>(l)) {
+        // And wN (ZExt wN X_M) mask where mask == 2^M-1 => ZExt wN X_M
+        // ZExt already zeros bits above M, so masking by the inner width is redundant.
+        auto innerW = ze->getKid(0)->getWidth();
+        if (innerW <= 64 && cr->getWidth() <= 64 && cr->getZExtValue() == bitmask<uint64_t>(innerW)) {
+            return l;
+        }
     }
 
     return AndExpr::alloc(l, cr);
@@ -1030,6 +1053,16 @@ static ref<Expr> AndExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
 static ref<Expr> AndExpr_create(Expr *l, Expr *r) {
     if (l->isNegationOf(r))
         return ConstantExpr::create(0, Expr::Bool);
+    // And wN (ZExt wN X_M) (ZExt wN Y_M) => ZExt wN (And wM X_M Y_M)
+    if (const ZExtExpr *lz = dyn_cast<ZExtExpr>(l)) {
+        if (const ZExtExpr *rz = dyn_cast<ZExtExpr>(r)) {
+            ref<Expr> lx = lz->getKid(0);
+            ref<Expr> rx = rz->getKid(0);
+            if (lx->getWidth() == rx->getWidth()) {
+                return ZExtExpr::create(AndExpr::create(lx, rx), l->getWidth());
+            }
+        }
+    }
     if (OrExpr *ae = dyn_cast<OrExpr>(l)) {
         // (!r || b) && r == b && r
         if (ae->getLeft()->isNegationOf(r))
@@ -1071,6 +1104,16 @@ static ref<Expr> OrExpr_createPartialR(const ref<ConstantExpr> &cl, Expr *r) {
 static ref<Expr> OrExpr_create(Expr *l, Expr *r) {
     if (l->isNegationOf(r))
         return ConstantExpr::create(1, Expr::Bool);
+    // Or wN (ZExt wN X_M) (ZExt wN Y_M) => ZExt wN (Or wM X_M Y_M)
+    if (const ZExtExpr *lz = dyn_cast<ZExtExpr>(l)) {
+        if (const ZExtExpr *rz = dyn_cast<ZExtExpr>(r)) {
+            ref<Expr> lx = lz->getKid(0);
+            ref<Expr> rx = rz->getKid(0);
+            if (lx->getWidth() == rx->getWidth()) {
+                return ZExtExpr::create(OrExpr::create(lx, rx), l->getWidth());
+            }
+        }
+    }
     /*
   if (EqExpr *e = dyn_cast<EqExpr>(l)) {
     if (e->getLeft()->isZero() && *r == *e->getRight()) {
@@ -1118,6 +1161,16 @@ static ref<Expr> XorExpr_create(Expr *l, Expr *r) {
         return ConstantExpr::alloc(0, l->getWidth());
     if (l->isNegationOf(r))
         return ConstantExpr::alloc(1, Expr::Bool);
+    // Xor wN (ZExt wN X_M) (ZExt wN Y_M) => ZExt wN (Xor wM X_M Y_M)
+    if (const ZExtExpr *lz = dyn_cast<ZExtExpr>(l)) {
+        if (const ZExtExpr *rz = dyn_cast<ZExtExpr>(r)) {
+            ref<Expr> lx = lz->getKid(0);
+            ref<Expr> rx = rz->getKid(0);
+            if (lx->getWidth() == rx->getWidth()) {
+                return ZExtExpr::create(XorExpr::create(lx, rx), l->getWidth());
+            }
+        }
+    }
     return XorExpr::alloc(l, r);
 }
 

--- a/klee/unittests/Expr/ExprTest.cpp
+++ b/klee/unittests/Expr/ExprTest.cpp
@@ -250,4 +250,147 @@ TEST(ExprTest, ExtractConcat) {
     EXPECT_EQ(Expr::Extract, concat2->getKid(0)->getKind());
     EXPECT_EQ(Expr::Extract, concat2->getKid(1)->getKind());
 }
+
+///
+/// \brief Check that ZExt(Extract(And(X, mask), 0, M)) simplifies to And(X, mask).
+///
+/// This pattern is common when 32-bit arithmetic is emulated in 64-bit registers:
+/// a 64-bit value is masked to 32 bits, extracted to w32, then zero-extended back
+/// to w64 — which is redundant since the And already zeroes the upper bits.
+///
+TEST(ExprTest, ZExtExtractAndMaskSimplification) {
+    // Use a 64-bit symbolic expression that is not a ZExt itself
+    auto loads = GenerateLoads({"x64"}, Expr::Int64);
+    ref<Expr> x64 = loads[0];
+
+    // Build And w64 X 0xffffffff
+    ref<Expr> mask = ConstantExpr::create(0xffffffff, Expr::Int64);
+    ref<Expr> andExpr = AndExpr::create(x64, mask);
+
+    // ZExt w64 (Extract w32 0 (And w64 X 0xffffffff)) should simplify to andExpr
+    ref<Expr> extract = ExtractExpr::create(andExpr, 0, Expr::Int32);
+    ref<Expr> zext = ZExtExpr::create(extract, Expr::Int64);
+    EXPECT_EQ(andExpr, zext);
+
+    // Also test with a 16-bit mask (w16 inner, w32 outer)
+    auto loads32 = GenerateLoads({"x32"}, Expr::Int32);
+    ref<Expr> x32 = loads32[0];
+    ref<Expr> mask16 = ConstantExpr::create(0xffff, Expr::Int32);
+    ref<Expr> andExpr16 = AndExpr::create(x32, mask16);
+    ref<Expr> extract16 = ExtractExpr::create(andExpr16, 0, Expr::Int16);
+    ref<Expr> zext16 = ZExtExpr::create(extract16, Expr::Int32);
+    EXPECT_EQ(andExpr16, zext16);
+}
+
+///
+/// \brief Check that And(ZExt wN X_M, mask) simplifies to ZExt wN X_M when mask == 2^M-1.
+///
+/// ZExt already zeros the upper bits, so masking to the inner width is redundant.
+///
+TEST(ExprTest, AndZExtMaskRedundant) {
+    auto loads = GenerateLoads({"a32", "b32"}, Expr::Int32);
+    ref<Expr> x32 = loads[0];
+
+    // ZExt w64 X_32
+    ref<Expr> zext = ZExtExpr::create(x32, Expr::Int64);
+
+    // And w64 (ZExt w64 X_32) 0xffffffff => ZExt w64 X_32
+    ref<Expr> masked = AndExpr::create(zext, ConstantExpr::create(0xffffffff, Expr::Int64));
+    EXPECT_EQ(zext, masked);
+
+    // Same check with 16-bit inner width
+    auto loads16 = GenerateLoads({"c16"}, Expr::Int16);
+    ref<Expr> x16 = loads16[0];
+    ref<Expr> zext32 = ZExtExpr::create(x16, Expr::Int32);
+    ref<Expr> masked16 = AndExpr::create(zext32, ConstantExpr::create(0xffff, Expr::Int32));
+    EXPECT_EQ(zext32, masked16);
+}
+
+///
+/// \brief Check that And/Or/Xor of two ZExt expressions is pushed inside the ZExt.
+///
+/// And wN (ZExt wN X_M) (ZExt wN Y_M) => ZExt wN (And wM X_M Y_M)
+/// Or  wN (ZExt wN X_M) (ZExt wN Y_M) => ZExt wN (Or  wM X_M Y_M)
+/// Xor wN (ZExt wN X_M) (ZExt wN Y_M) => ZExt wN (Xor wM X_M Y_M)
+///
+/// Since the rule creates new expression nodes, we verify the result structure
+/// using getKind() and pointer equality on the leaf operands (x32, y32).
+///
+TEST(ExprTest, BinaryOpZExtPushdown) {
+    auto loads = GenerateLoads({"p32", "q32"}, Expr::Int32);
+    ref<Expr> x32 = loads[0];
+    ref<Expr> y32 = loads[1];
+
+    ref<Expr> zx = ZExtExpr::create(x32, Expr::Int64);
+    ref<Expr> zy = ZExtExpr::create(y32, Expr::Int64);
+
+    // And wN (ZExt X) (ZExt Y) => ZExt wN (And wM X Y)
+    ref<Expr> andResult = AndExpr::create(zx, zy);
+    ASSERT_EQ(Expr::ZExt, andResult->getKind());
+    EXPECT_EQ(Expr::Int64, andResult->getWidth());
+    ASSERT_EQ(Expr::And, andResult->getKid(0)->getKind());
+    EXPECT_EQ(x32, andResult->getKid(0)->getKid(0));
+    EXPECT_EQ(y32, andResult->getKid(0)->getKid(1));
+
+    // Or wN (ZExt X) (ZExt Y) => ZExt wN (Or wM X Y)
+    ref<Expr> orResult = OrExpr::create(zx, zy);
+    ASSERT_EQ(Expr::ZExt, orResult->getKind());
+    EXPECT_EQ(Expr::Int64, orResult->getWidth());
+    ASSERT_EQ(Expr::Or, orResult->getKid(0)->getKind());
+    EXPECT_EQ(x32, orResult->getKid(0)->getKid(0));
+    EXPECT_EQ(y32, orResult->getKid(0)->getKid(1));
+
+    // Xor wN (ZExt X) (ZExt Y) => ZExt wN (Xor wM X Y)
+    ref<Expr> xorResult = XorExpr::create(zx, zy);
+    ASSERT_EQ(Expr::ZExt, xorResult->getKind());
+    EXPECT_EQ(Expr::Int64, xorResult->getWidth());
+    ASSERT_EQ(Expr::Xor, xorResult->getKid(0)->getKind());
+    EXPECT_EQ(x32, xorResult->getKid(0)->getKid(0));
+    EXPECT_EQ(y32, xorResult->getKid(0)->getKid(1));
+
+    // Also verify with 16->32 bit extension
+    auto loads16 = GenerateLoads({"r16", "s16"}, Expr::Int16);
+    ref<Expr> r16 = loads16[0];
+    ref<Expr> s16 = loads16[1];
+    ref<Expr> zr = ZExtExpr::create(r16, Expr::Int32);
+    ref<Expr> zs = ZExtExpr::create(s16, Expr::Int32);
+
+    ref<Expr> andResult16 = AndExpr::create(zr, zs);
+    ASSERT_EQ(Expr::ZExt, andResult16->getKind());
+    EXPECT_EQ(Expr::Int32, andResult16->getWidth());
+    ASSERT_EQ(Expr::And, andResult16->getKid(0)->getKind());
+    EXPECT_EQ(r16, andResult16->getKid(0)->getKid(0));
+    EXPECT_EQ(s16, andResult16->getKid(0)->getKid(1));
+}
+
+///
+/// \brief Check the chained simplification that models 32-bit ops in 64-bit registers.
+///
+/// The pattern ZExt w64 (Extract w32 0 (And w64 (ZExt w64 X_32) 0xffffffff))
+/// should fully collapse through chained rules:
+///   1. And(ZExt X, 0xffffffff) => ZExt X      (redundant mask, pointer equality)
+///   2. Extract w32 0 (ZExt w64 X_32) => X_32  (existing rule, pointer equality)
+///   3. ZExt w64 X_32                           (verify structure)
+///
+TEST(ExprTest, ZExtRoundtripChain) {
+    auto loads = GenerateLoads({"chain32"}, Expr::Int32);
+    ref<Expr> x32 = loads[0];
+
+    ref<Expr> zext64 = ZExtExpr::create(x32, Expr::Int64);
+
+    // Step 1: And(ZExt X, mask) => ZExt X (returns the same ZExt pointer)
+    ref<Expr> andMasked = AndExpr::create(zext64, ConstantExpr::create(0xffffffff, Expr::Int64));
+    EXPECT_EQ(zext64, andMasked);
+
+    // Step 2: Extract w32 0 (ZExt w64 X_32) => X_32 (returns the original x32 pointer)
+    ref<Expr> extracted = ExtractExpr::create(andMasked, 0, Expr::Int32);
+    EXPECT_EQ(x32, extracted);
+
+    // Step 3: ZExt w64 X_32 — re-extension produces a new ZExt node wrapping x32
+    ref<Expr> reExtended = ZExtExpr::create(extracted, Expr::Int64);
+    ASSERT_EQ(Expr::ZExt, reExtended->getKind());
+    EXPECT_EQ(Expr::Int64, reExtended->getWidth());
+    EXPECT_EQ(x32, reExtended->getKid(0));
+}
+
 } // namespace

--- a/klee/unittests/Expr/ExprTest.cpp
+++ b/klee/unittests/Expr/ExprTest.cpp
@@ -60,6 +60,9 @@ static ref<Expr> ReadUnalignedWord(const ObjectStatePtr &os, unsigned addr, unsi
     unsigned addr2 = addr1 + dataSize;
     unsigned shift = (addr & (dataSize - 1)) * 8;
     ref<Expr> res1 = os->read(addr1, dataSize * 8);
+    if (shift == 0) {
+        return res1;
+    }
     ref<Expr> res2 = os->read(addr2, dataSize * 8);
 
     // clang-format off

--- a/klee/unittests/Expr/ExprTest.cpp
+++ b/klee/unittests/Expr/ExprTest.cpp
@@ -393,4 +393,71 @@ TEST(ExprTest, ZExtRoundtripChain) {
     EXPECT_EQ(x32, reExtended->getKid(0));
 }
 
+///
+/// \brief Check that Ule/Ult/Sle/Slt of identical symbolic expressions simplify.
+///
+/// Ule x x => true, Ult x x => false, Sle x x => true, Slt x x => false.
+///
+TEST(ExprTest, CompareIdentical) {
+    auto loads = GenerateLoads({"cmp32"}, Expr::Int32);
+    ref<Expr> x = loads[0];
+
+    ref<Expr> t = ConstantExpr::create(1, Expr::Bool);
+    ref<Expr> f = ConstantExpr::create(0, Expr::Bool);
+
+    EXPECT_EQ(t, UleExpr::create(x, x));
+    EXPECT_EQ(f, UltExpr::create(x, x));
+    EXPECT_EQ(t, SleExpr::create(x, x));
+    EXPECT_EQ(f, SltExpr::create(x, x));
+}
+
+///
+/// \brief Check that Ule C (Add C (ZExt x)) simplifies to true when no overflow is possible.
+///
+/// C <= C + ZExt(x) is trivially true because ZExt(x) >= 0 and C + max(ZExt) fits in the width.
+///
+TEST(ExprTest, UleSelfPlusZExt) {
+    auto loads = GenerateLoads({"z32"}, Expr::Int32);
+    ref<Expr> x32 = loads[0];
+
+    auto zext = ZExtExpr::create(x32, Expr::Int64);
+    auto c = ConstantExpr::create(0x7f5855589c50ULL, Expr::Int64);
+    // Add normalises constant to the left: Add(C, ZExt)
+    auto add = AddExpr::create(c, zext);
+    auto ule = UleExpr::create(c, add);
+    EXPECT_EQ(ref<Expr>(ConstantExpr::create(1, Expr::Bool)), ule);
+
+    // Overflow check: if C is large enough that C + UINT32_MAX would overflow, do NOT simplify.
+    auto cBig = ConstantExpr::create(UINT64_MAX - 5, Expr::Int64);
+    auto addBig = AddExpr::create(cBig, zext);
+    auto uleBig = UleExpr::create(cBig, addBig);
+    EXPECT_NE(ref<Expr>(ConstantExpr::create(1, Expr::Bool)), uleBig);
+}
+
+///
+/// \brief Check that Ule (Add C (ZExt (And x mask))) D simplifies to true
+///        when C + mask <= D.
+///
+TEST(ExprTest, UleAddZExtAndMask) {
+    auto loads = GenerateLoads({"m32"}, Expr::Int32);
+    ref<Expr> x32 = loads[0];
+
+    // N0 = ZExt w64 (And w32 x 0xFF) — max value is 0xFF
+    auto mask = ConstantExpr::create(0xFF, Expr::Int32);
+    auto inner = AndExpr::create(x32, mask);
+    auto zext = ZExtExpr::create(inner, Expr::Int64);
+
+    // C + 0xFF == D  => always true
+    auto c = ConstantExpr::create(0x7f5855589c51ULL, Expr::Int64);
+    auto d = ConstantExpr::create(0x7f5855589d50ULL, Expr::Int64); // c + 0xFF
+    auto add = AddExpr::create(c, zext);
+    auto ule = UleExpr::create(add, d);
+    EXPECT_EQ(ref<Expr>(ConstantExpr::create(1, Expr::Bool)), ule);
+
+    // C + 0xFF > D  => NOT simplified to true
+    auto dSmall = ConstantExpr::create(0x7f5855589d4fULL, Expr::Int64); // c + 0xFF - 1
+    auto uleSmall = UleExpr::create(add, dSmall);
+    EXPECT_NE(ref<Expr>(ConstantExpr::create(1, Expr::Bool)), uleSmall);
+}
+
 } // namespace

--- a/libcpu/include/cpu/common.h
+++ b/libcpu/include/cpu/common.h
@@ -71,6 +71,8 @@ typedef struct CPUWatchpoint {
     long temp_buf[CPU_TEMP_BUF_NLONGS];                                                               \
     /* Used to handle self-modifying code */                                                          \
     unsigned restored_instruction_size;                                                               \
+    /* Set when the LLVM interpreter should exit the current TB (e.g., self-modifying code) */        \
+    uint32_t se_tb_abort;                                                                             \
                                                                                                       \
     /* from this point: preserved by CPU reset */                                                     \
     /* ice debug support */                                                                           \

--- a/libcpu/include/cpu/i386/cpu.h
+++ b/libcpu/include/cpu/i386/cpu.h
@@ -234,6 +234,8 @@ void cpu_set_eflags(CPUX86State *env, target_ulong eflags);
 
 uint32_t cpu_compute_hflags(const CPUX86State *env);
 
+int cpu_get_pic_interrupt(CPUX86State *env);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libcpu/include/cpu/kvm.h
+++ b/libcpu/include/cpu/kvm.h
@@ -173,6 +173,7 @@ struct kvm_pit_config {
 #define KVM_EXIT_S390_TSCH       22
 #define KVM_EXIT_EPR             23
 #define KVM_EXIT_SYSTEM_EVENT    24
+#define KVM_EXIT_IOAPIC_EOI      26
 
 /* Symbolic execution exit codes */
 #define KVM_EXIT_FLUSH_DISK        100
@@ -317,6 +318,10 @@ struct kvm_run {
             __u32 type;
             __u64 flags;
         } system_event;
+        /* KVM_EXIT_IOAPIC_EOI */
+        struct {
+            __u8 vector;
+        } eoi;
         /* Fix the size of the union. */
         char padding[256];
     };
@@ -762,6 +767,9 @@ struct kvm_ppc_smmu_info {
 #define KVM_CAP_PPC_FIXUP_HCALL         103
 #define KVM_CAP_PPC_ENABLE_HCALL        104
 #define KVM_CAP_CHECK_EXTENSION_VM      105
+#define KVM_CAP_SPLIT_IRQCHIP           121
+#define KVM_CAP_IOEVENTFD_ANY_LENGTH    122
+#define KVM_CAP_MAX_VCPU_ID             128
 
 #define KVM_CAP_IMMEDIATE_EXIT 136
 
@@ -1247,5 +1255,81 @@ struct kvm_assigned_msix_entry {
     __u16 entry; /* The index of entry in the MSI-X table */
     __u16 padding[3];
 };
+
+/**
+ * struct kvm_stats_header - Header of per vm/vcpu binary statistics data.
+ * @flags: Some extra information for header, always 0 for now.
+ * @name_size: The size in bytes of the memory which contains statistics
+ *             name string including trailing '\0'. The memory is allocated
+ *             at the send of statistics descriptor.
+ * @num_desc: The number of statistics the vm or vcpu has.
+ * @id_offset: The offset of the vm/vcpu stats' id string in the file pointed
+ *             by vm/vcpu stats fd.
+ * @desc_offset: The offset of the vm/vcpu stats' descriptor block in the file
+ *               pointd by vm/vcpu stats fd.
+ * @data_offset: The offset of the vm/vcpu stats' data block in the file
+ *               pointed by vm/vcpu stats fd.
+ *
+ * This is the header userspace needs to read from stats fd before any other
+ * readings. It is used by userspace to discover all the information about the
+ * vm/vcpu's binary statistics.
+ * Userspace reads this header from the start of the vm/vcpu's stats fd.
+ */
+struct kvm_stats_header {
+    __u32 flags;
+    __u32 name_size;
+    __u32 num_desc;
+    __u32 id_offset;
+    __u32 desc_offset;
+    __u32 data_offset;
+};
+
+#define KVM_STATS_TYPE_SHIFT       0
+#define KVM_STATS_TYPE_MASK        (0xF << KVM_STATS_TYPE_SHIFT)
+#define KVM_STATS_TYPE_CUMULATIVE  (0x0 << KVM_STATS_TYPE_SHIFT)
+#define KVM_STATS_TYPE_INSTANT     (0x1 << KVM_STATS_TYPE_SHIFT)
+#define KVM_STATS_TYPE_PEAK        (0x2 << KVM_STATS_TYPE_SHIFT)
+#define KVM_STATS_TYPE_LINEAR_HIST (0x3 << KVM_STATS_TYPE_SHIFT)
+#define KVM_STATS_TYPE_LOG_HIST    (0x4 << KVM_STATS_TYPE_SHIFT)
+#define KVM_STATS_TYPE_MAX         KVM_STATS_TYPE_LOG_HIST
+
+#define KVM_STATS_UNIT_SHIFT   4
+#define KVM_STATS_UNIT_MASK    (0xF << KVM_STATS_UNIT_SHIFT)
+#define KVM_STATS_UNIT_NONE    (0x0 << KVM_STATS_UNIT_SHIFT)
+#define KVM_STATS_UNIT_BYTES   (0x1 << KVM_STATS_UNIT_SHIFT)
+#define KVM_STATS_UNIT_SECONDS (0x2 << KVM_STATS_UNIT_SHIFT)
+#define KVM_STATS_UNIT_CYCLES  (0x3 << KVM_STATS_UNIT_SHIFT)
+#define KVM_STATS_UNIT_BOOLEAN (0x4 << KVM_STATS_UNIT_SHIFT)
+#define KVM_STATS_UNIT_MAX     KVM_STATS_UNIT_BOOLEAN
+
+#define KVM_STATS_BASE_SHIFT 8
+#define KVM_STATS_BASE_MASK  (0xF << KVM_STATS_BASE_SHIFT)
+#define KVM_STATS_BASE_POW10 (0x0 << KVM_STATS_BASE_SHIFT)
+#define KVM_STATS_BASE_POW2  (0x1 << KVM_STATS_BASE_SHIFT)
+#define KVM_STATS_BASE_MAX   KVM_STATS_BASE_POW2
+
+/**
+ * struct kvm_stats_desc - Descriptor of a KVM statistics.
+ * @flags: Annotations of the stats, like type, unit, etc.
+ * @exponent: Used together with @flags to determine the unit.
+ * @size: The number of data items for this stats.
+ *        Every data item is of type __u64.
+ * @offset: The offset of the stats to the start of stat structure in
+ *          structure kvm or kvm_vcpu.
+ * @bucket_size: A parameter value used for histogram stats. It is only used
+ *		for linear histogram stats, specifying the size of the bucket;
+ * @name: The name string for the stats. Its size is indicated by the
+ *        &kvm_stats_header->name_size.
+ */
+struct kvm_stats_desc {
+    __u32 flags;
+    __s16 exponent;
+    __u16 size;
+    __u32 offset;
+    __u32 bucket_size;
+    char name[];
+};
+
+#define KVM_GET_STATS_FD _IO(KVMIO, 0xce)
 
 #endif /* __LINUX_KVM_H */

--- a/libcpu/src/cpu-exec.c
+++ b/libcpu/src/cpu-exec.c
@@ -272,6 +272,7 @@ static uintptr_t fetch_and_run_tb(TranslationBlock *prev_tb, int tb_exit_code, C
     }
 
 #if defined(CONFIG_SYMBEX)
+    env->se_tb_abort = 0;
     env->se_current_tb = tb;
     if (likely(*g_sqi.mode.fast_concrete_invocation)) {
         **g_sqi.mode.running_exception_emulation_code = 0;

--- a/libcpu/src/cpu-exec.c
+++ b/libcpu/src/cpu-exec.c
@@ -19,20 +19,12 @@
 #include <cpu/config.h>
 #include <cpu/types.h>
 #include <tcg/tcg.h>
+#include <tcg/utils/log.h>
 #include "cpu.h"
 #include "exec-tb.h"
 
 #ifdef CONFIG_SYMBEX
 #include <cpu/se_libcpu.h>
-#endif
-
-// #define DEBUG_EXEC
-// #define TRACE_EXEC
-
-#ifdef DEBUG_EXEC
-#define DPRINTF(...) fprintf(logfile, __VA_ARGS__)
-#else
-#define DPRINTF(...)
 #endif
 
 #if defined(CONFIG_SYMBEX_MP)
@@ -203,9 +195,6 @@ static void cpu_handle_debug_exception(CPUArchState *env) {
 
 /* main execution loop */
 
-// volatile sig_atomic_t exit_request;
-
-#ifdef TRACE_EXEC
 static void dump_regs(CPUX86State *env, int isStart) {
 #if defined(CONFIG_SYMBEX)
     target_ulong eax, ebx, ecx, edx, esi, edi, ebp, esp;
@@ -230,7 +219,6 @@ static void dump_regs(CPUX86State *env, int isStart) {
             (uint64_t) env->segs[R_SS].selector, (uint64_t) env->regs[R_ESP]);
 #endif
 }
-#endif
 
 static uintptr_t fetch_and_run_tb(TranslationBlock *prev_tb, int tb_exit_code, CPUArchState *env) {
     uint8_t *tc_ptr;
@@ -238,19 +226,17 @@ static uintptr_t fetch_and_run_tb(TranslationBlock *prev_tb, int tb_exit_code, C
 
     TranslationBlock *tb = tb_find_fast(env);
 
-    DPRINTF("fetch_and_run_tb cs:eip=%#lx:%#lx e=%#lx fl=%lx riw=%d\n", (uint64_t) env->segs[R_CS].selector,
-            (uint64_t) env->eip, (uint64_t) env->eip + tb->size, (uint64_t) env->mflags,
-            env->kvm_request_interrupt_window);
+    libcpu_log_mask(CPU_LOG_EXEC, "fetch_and_run_tb cs:eip=%#lx:%#lx e=%#lx fl=%lx riw=%d\n",
+                    (uint64_t) env->segs[R_CS].selector, (uint64_t) env->eip, (uint64_t) env->eip + tb->size,
+                    (uint64_t) env->mflags, env->kvm_request_interrupt_window);
 
     if (tb_invalidated_flag) {
         prev_tb = NULL;
         tb_invalidated_flag = 0;
     }
 
-#ifdef CONFIG_DEBUG_EXEC
-    libcpu_log_mask(CPU_LOG_EXEC, "Trace 0x%08lx [" TARGET_FMT_lx "] %s\n", (long) tb->tc_ptr, tb->pc,
-                    lookup_symbol(tb->pc));
-#endif
+    libcpu_log_mask(CPU_LOG_EXEC, "Trace 0x%08lx [%016" PRIx64 "]\n", (long) tb->tc.ptr, tb->pc);
+
     /*
      * see if we can patch the calling TB. When the TB
      * spans two pages, we cannot safely do a direct jump.
@@ -281,9 +267,9 @@ static uintptr_t fetch_and_run_tb(TranslationBlock *prev_tb, int tb_exit_code, C
 
     /* execute the generated code */
 
-#ifdef TRACE_EXEC
-    dump_regs(env, 1);
-#endif
+    if (libcpu_log_enabled() && libcpu_loglevel_mask(CPU_LOG_EXEC)) {
+        dump_regs(env, 1);
+    }
 
 #if defined(CONFIG_SYMBEX)
     env->se_current_tb = tb;
@@ -300,9 +286,9 @@ static uintptr_t fetch_and_run_tb(TranslationBlock *prev_tb, int tb_exit_code, C
 
 #endif
 
-#ifdef TRACE_EXEC
-    dump_regs(env, 0);
-#endif
+    if (libcpu_log_enabled() && libcpu_loglevel_mask(CPU_LOG_EXEC)) {
+        dump_regs(env, 0);
+    }
 
     env->current_tb = NULL;
 
@@ -318,8 +304,8 @@ static bool process_interrupt_request(CPUArchState *env) {
 
     bool has_interrupt = false;
 
-    DPRINTF("  process_interrupt intrq=%#x mflags=%#lx hf1=%#x hf2=%#x\n", interrupt_request, (uint64_t) env->mflags,
-            env->hflags, env->hflags2);
+    libcpu_log_mask(CPU_LOG_INT, "  process_interrupt intrq=%#x mflags=%#lx hf1=%#x hf2=%#x\n", interrupt_request,
+                    (uint64_t) env->mflags, env->hflags, env->hflags2);
 
     if (unlikely(env->singlestep_enabled & SSTEP_NOIRQ)) {
         /* Mask out external interrupts for this step. */
@@ -367,10 +353,7 @@ static bool process_interrupt_request(CPUArchState *env) {
 
             libcpu_log_mask(CPU_LOG_INT, "Servicing hardware INT=%d\n", intno);
             if (intno >= 0) {
-#ifdef SE_KVM_DEBUG_IRQ
-                DPRINTF("Handling interrupt %d\n", intno);
-#endif
-
+                libcpu_log_mask(CPU_LOG_INT, "Handling interrupt INT=%d\n", intno);
                 do_interrupt_x86_hardirq(env, intno, 1);
             }
 
@@ -415,7 +398,7 @@ static int process_exceptions(CPUArchState *env) {
             cpu_handle_debug_exception(env);
         }
     } else {
-        DPRINTF("  do_interrupt exidx=%x\n", env->exception_index);
+        libcpu_log_mask(CPU_LOG_INT, "  do_interrupt exidx=%x\n", env->exception_index);
         do_interrupt(env);
         env->exception_index = -1;
     }
@@ -438,7 +421,7 @@ static bool execution_loop(CPUArchState *env) {
         }
 
         if (unlikely(!has_interrupt && env->exit_request)) {
-            DPRINTF("  execution_loop: exit_request\n");
+            libcpu_log_mask(CPU_LOG_EXEC, "  execution_loop: exit_request\n");
             env->exit_request = 0;
             env->exception_index = EXCP_INTERRUPT;
 
@@ -464,9 +447,9 @@ static bool execution_loop(CPUArchState *env) {
         ltb = (TranslationBlock *) (last_tb & ~TB_EXIT_MASK);
 
         if (ltb) {
-            DPRINTF("ltb s=%#lx e=%#lx fl=%lx exit_code=%x riw=%d\n", (uint64_t) ltb->pc,
-                    (uint64_t) ltb->pc + ltb->size, (uint64_t) env->mflags, last_tb_exit_code,
-                    env->kvm_request_interrupt_window);
+            libcpu_log_mask(CPU_LOG_EXEC, "ltb s=%#lx e=%#lx fl=%lx exit_code=%x riw=%d\n", (uint64_t) ltb->pc,
+                            (uint64_t) ltb->pc + ltb->size, (uint64_t) env->mflags, last_tb_exit_code,
+                            env->kvm_request_interrupt_window);
         }
 
         if (last_tb_exit_code > TB_EXIT_IDXMAX) {
@@ -506,7 +489,8 @@ int cpu_exec(CPUArchState *env) {
 
     env->exception_index = -1;
 
-    DPRINTF("cpu_loop enter mflags=%#lx hf1=%#x hf2=%#x\n", (uint64_t) env->mflags, env->hflags, env->hflags2);
+    libcpu_log_mask(CPU_LOG_EXEC, "cpu_loop enter mflags=%#lx hf1=%#x hf2=%#x\n", (uint64_t) env->mflags, env->hflags,
+                    env->hflags2);
 
     /* prepare setjmp context for exception handling */
     for (;;) {
@@ -518,7 +502,7 @@ int cpu_exec(CPUArchState *env) {
              */
             env->current_tb = NULL;
 
-            DPRINTF("  setjmp entered eip=%#lx\n", (uint64_t) env->eip);
+            libcpu_log_mask(CPU_LOG_EXEC, "  setjmp entered eip=%#lx\n", (uint64_t) env->eip);
 
 #ifdef CONFIG_SYMBEX
             assert(env->exception_index != EXCP_SE);
@@ -561,7 +545,7 @@ int cpu_exec(CPUArchState *env) {
             env = cpu_single_env;
         }
     } /* for(;;) */
-    DPRINTF("cpu_loop exit ret=%#x eip=%#lx\n", ret, (uint64_t) env->eip);
+    libcpu_log_mask(CPU_LOG_EXEC, "cpu_loop exit ret=%#x eip=%#lx\n", ret, (uint64_t) env->eip);
 
     env->current_tb = NULL;
 

--- a/libcpu/src/cpu-exec.c
+++ b/libcpu/src/cpu-exec.c
@@ -358,12 +358,14 @@ static bool process_interrupt_request(CPUArchState *env) {
                     (!(env->hflags2 & HF2_VINTR_MASK) &&
                      (env->mflags & IF_MASK && !(env->hflags & HF_INHIBIT_IRQ_MASK))))) {
             int intno;
+
             svm_check_intercept(env, SVM_EXIT_INTR);
             env->interrupt_request &= ~(CPU_INTERRUPT_HARD | CPU_INTERRUPT_VIRQ);
-            intno = env->kvm_irq;
-            env->kvm_irq = -1;
 
-            libcpu_log_mask(CPU_LOG_INT, "Servicing hardware INT=0x%02x\n", intno);
+            intno = cpu_get_pic_interrupt(env);
+            assert(intno >= 0);
+
+            libcpu_log_mask(CPU_LOG_INT, "Servicing hardware INT=%d\n", intno);
             if (intno >= 0) {
 #ifdef SE_KVM_DEBUG_IRQ
                 DPRINTF("Handling interrupt %d\n", intno);

--- a/libcpu/src/cpu-exec.c
+++ b/libcpu/src/cpu-exec.c
@@ -430,8 +430,6 @@ static bool execution_loop(CPUArchState *env) {
             cpu_loop_exit(env);
         }
 
-        env->exit_request = 0;
-
 #if defined(DEBUG_DISAS) || defined(CONFIG_DEBUG_EXEC)
         if (libcpu_loglevel_mask(CPU_LOG_TB_CPU)) {
 #if defined(TARGET_I386)

--- a/libcpu/src/exec-tb.c
+++ b/libcpu/src/exec-tb.c
@@ -395,6 +395,10 @@ void tb_invalidate_phys_page_range(tb_page_addr_t start, tb_page_addr_t end, int
                 if (env->mem_io_pc) {
                     /* now we have a real cpu fault */
                     current_tb = tcg_tb_lookup(env->mem_io_pc);
+                } else {
+#ifdef CONFIG_SYMBEX
+                    env->se_tb_abort = 1;
+#endif
                 }
             }
             if (current_tb == tb && (current_tb->cflags & CF_COUNT_MASK) != 1) {
@@ -443,18 +447,6 @@ void tb_invalidate_phys_page_range(tb_page_addr_t start, tb_page_addr_t end, int
 #endif
         }
     }
-
-#ifdef TARGET_HAS_PRECISE_SMC
-#ifdef CONFIG_SYMBEX
-/* In symbex mode, we don't keep env->mem_io_pc information, so we can't be
-   sure whether current tb was invalidated or not. We abort it
-   in any case */
-/* XXX: is it safe to do ? */
-// env->current_tb = NULL;
-// cpu_resume_from_signal(env, NULL);
-// XXX: check env->mem_io_pc handling!
-#endif
-#endif
 }
 
 /* len must be <= 8 and start must be a multiple of len */

--- a/libcpu/src/softmmu_template.h
+++ b/libcpu/src/softmmu_template.h
@@ -529,7 +529,7 @@ void glue(glue(glue(HELPER_PREFIX, st), SUFFIX), MMUSUFFIX)(CPUArchState *env, t
 redo:
     tlb_entry = &env->tlb_table[mmu_idx].table[index];
     tlb_addr = tlb_entry->addr_write & ~TLB_MEM_TRACE;
-    ;
+
     if (likely((addr & TARGET_PAGE_MASK) == (tlb_addr & (TARGET_PAGE_MASK | TLB_INVALID_MASK)))) {
         if (unlikely(tlb_addr & ~TARGET_PAGE_MASK)) {
             /* IO access */

--- a/libcpu/src/translate-all.c
+++ b/libcpu/src/translate-all.c
@@ -112,6 +112,7 @@ static void cpu_gen_init(TCGContext *ctx) {
 
 #ifdef CONFIG_SYMBEX
     ctx->tlbe_offset_symbex_addend = offsetof(CPUTLBEntry, se_addend);
+    ctx->env_offset_se_tb_abort = offsetof(CPUArchState, se_tb_abort);
 #endif
 
     ctx->target_page_bits = TARGET_PAGE_BITS;

--- a/libs2e/src/CMakeLists.txt
+++ b/libs2e/src/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
     s2e-kvm-vcpu.cpp
     s2e-libcpu-interface.cpp
     crashdump.cpp
+    hw/lapic.cpp
 )
 
 add_executable(

--- a/libs2e/src/hw/lapic.cpp
+++ b/libs2e/src/hw/lapic.cpp
@@ -1,0 +1,705 @@
+///
+/// Copyright (C) 2026, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#include <cstdio>
+#include <cstring>
+
+#include <cpu/i386/defs.h>
+#include <cpu/interrupt.h>
+#include <cpu/kvm.h>
+#include <timer.h>
+
+#include "../s2e-kvm-vcpu.h"
+#include "lapic.h"
+
+namespace s2e {
+namespace kvm {
+
+static constexpr uint32_t APICBASE_EXTD = 1 << 10;
+static constexpr uint32_t APICBASE_ENABLE = 1 << 11;
+
+static constexpr uint32_t ESR_ILLEGAL_ADDRESS = 1 << 7;
+
+static constexpr uint32_t SV_ENABLE = 1 << 8;
+
+static constexpr uint32_t LVT_MASKED = 1 << 16;
+static constexpr uint32_t LVT_LEVEL_TRIGGER = 1 << 15;
+static constexpr uint32_t LVT_TIMER_PERIODIC = 1 << 17;
+static constexpr uint32_t LVT_TIMER_TSCDEADLINE = 2 << 17;
+
+LocalApic::LocalApic(uint64_t phys_base, CpuInterruptFn cpu_interrupt, CpuExitFn cpu_exit)
+    : m_cpu_interrupt(std::move(cpu_interrupt)), m_cpu_exit(std::move(cpu_exit)) {
+    m_version = 0x14;
+    m_apic_base = phys_base | APICBASE_ENABLE;
+    m_dest_mode = 0xf;
+    m_spurious_vec = 0xff;
+    m_lvt.fill(LVT_MASKED);
+    m_timer = libcpu_new_timer(vm_clock, 1, timer_callback, this);
+}
+
+LocalApic::~LocalApic() {
+    libcpu_free_timer(m_timer);
+}
+
+void LocalApic::set_tpr(uint8_t val) {
+    m_tpr = val;
+    update_irq();
+}
+
+void LocalApic::set_apic_base(uint64_t val) {
+    printf("Setting APIC base to %#" PRIx64 "\n", val);
+    m_apic_base = (val & ~0xfffULL) | (val & (APICBASE_ENABLE | APICBASE_EXTD));
+}
+
+bool LocalApic::enabled() const {
+    return m_apic_base & APICBASE_ENABLE;
+}
+
+///
+/// Bit manipulation helpers for 256-bit interrupt registers (ISR, TMR, IRR).
+/// Each register is represented as an array of 8 uint32_t words.
+///
+
+void LocalApic::set_bit(uint32_t *tab, int index) {
+    int i = index >> 5;
+    uint32_t mask = 1u << (index & 0x1f);
+    tab[i] |= mask;
+}
+
+int LocalApic::get_bit(const uint32_t *tab, int index) {
+    int i = index >> 5;
+    uint32_t mask = 1u << (index & 0x1f);
+    return !!(tab[i] & mask);
+}
+
+void LocalApic::reset_bit(uint32_t *tab, int index) {
+    int i = index >> 5;
+    uint32_t mask = 1u << (index & 0x1f);
+    tab[i] &= ~mask;
+}
+
+int LocalApic::get_highest_priority_int(const uint32_t *tab) {
+    for (int i = 7; i >= 0; i--) {
+        if (tab[i] != 0) {
+            return i * 32 + (31 - __builtin_clz(tab[i]));
+        }
+    }
+    return -1;
+}
+
+bool LocalApic::is_x2apic_mode() const {
+    return m_apic_base & APICBASE_EXTD;
+}
+
+int LocalApic::get_ppr() const {
+    int tpr = m_tpr >> 4;
+    int isrv = get_highest_priority_int(m_isr.data());
+    if (isrv < 0) {
+        isrv = 0;
+    }
+    isrv >>= 4;
+    if (tpr >= isrv) {
+        return m_tpr;
+    }
+    return isrv << 4;
+}
+
+int LocalApic::get_arb_pri() const {
+    return 0;
+}
+
+void LocalApic::update_irq() {
+    if (irq_pending() > 0) {
+        m_cpu_interrupt(CPU_INTERRUPT_HARD, false);
+    } else {
+        m_cpu_interrupt(CPU_INTERRUPT_HARD, true);
+    }
+}
+
+void LocalApic::eoi() {
+    int isrv = get_highest_priority_int(m_isr.data());
+    if (isrv < 0) {
+        return;
+    }
+    reset_bit(m_isr.data(), isrv);
+
+    if (!(m_spurious_vec & APIC_SV_DIRECTED_IO) && get_bit(m_tmr.data(), isrv)) {
+        ioapic_eoi_broadcast(isrv);
+    }
+
+    update_irq();
+}
+
+void LocalApic::ioapic_eoi_broadcast(int vector) {
+    g_kvm_vcpu_buffer->exit_reason = KVM_EXIT_IOAPIC_EOI;
+    g_kvm_vcpu_buffer->eoi.vector = vector;
+    m_cpu_exit();
+}
+
+void LocalApic::set_irq(int vector_num, int trigger_mode) {
+    set_bit(m_irr.data(), vector_num);
+
+    if (get_bit(m_tmr.data(), vector_num) != !!trigger_mode) {
+        if (trigger_mode) {
+            set_bit(m_tmr.data(), vector_num);
+        } else {
+            reset_bit(m_tmr.data(), vector_num);
+        }
+    }
+    update_irq();
+}
+
+int LocalApic::irq_pending() const {
+    if (!(m_spurious_vec & SV_ENABLE)) {
+        return 0;
+    }
+
+    int irrv = get_highest_priority_int(m_irr.data());
+    if (irrv < 0) {
+        return 0;
+    }
+
+    int ppr = get_ppr();
+    if (ppr && (irrv & 0xf0) <= (ppr & 0xf0)) {
+        return -1;
+    }
+
+    return irrv;
+}
+
+int LocalApic::get_interrupt() {
+    if (!(m_spurious_vec & SV_ENABLE)) {
+        return -1;
+    }
+
+    int intno = irq_pending();
+
+    if (intno == 0) {
+        return -1;
+    } else if (intno < 0) {
+        return m_spurious_vec & 0xff;
+    }
+
+    reset_bit(m_irr.data(), intno);
+    set_bit(m_isr.data(), intno);
+
+    return intno;
+}
+
+void LocalApic::local_deliver(int vector) {
+    uint32_t lvt = m_lvt[vector];
+
+    if (lvt & LVT_MASKED) {
+        return;
+    }
+
+    int delivery_mode = (lvt >> 8) & 7;
+    switch (delivery_mode) {
+        case DM_FIXED: {
+            int trigger_mode = 0;
+            if ((vector == LVT_LINT0 || vector == LVT_LINT1) && (lvt & LVT_LEVEL_TRIGGER)) {
+                trigger_mode = 1;
+            }
+            set_irq(lvt & 0xff, trigger_mode);
+            break;
+        }
+        case DM_SMI:
+            m_cpu_interrupt(CPU_INTERRUPT_SMI, false);
+            break;
+        case DM_NMI:
+            m_cpu_interrupt(CPU_INTERRUPT_NMI, false);
+            break;
+        case DM_EXTINT:
+            m_cpu_interrupt(CPU_INTERRUPT_HARD, false);
+            break;
+        default:
+            break;
+    }
+}
+
+void LocalApic::timer_callback(void *opaque) {
+    static_cast<LocalApic *>(opaque)->on_timer();
+}
+
+void LocalApic::on_timer() {
+    local_deliver(LVT_TIMER);
+    timer_update(m_next_time);
+}
+
+bool LocalApic::next_timer(int64_t current_time) {
+    m_timer_expiry = -1;
+
+    if (m_lvt[LVT_TIMER] & LVT_TIMER_TSCDEADLINE) {
+        return false;
+    }
+
+    int64_t d = (current_time - m_initial_count_load_time) >> m_count_shift;
+
+    if (m_lvt[LVT_TIMER] & LVT_TIMER_PERIODIC) {
+        if (!m_initial_count) {
+            return false;
+        }
+        d = ((d / ((uint64_t) m_initial_count + 1)) + 1) * ((uint64_t) m_initial_count + 1);
+    } else {
+        if (d >= m_initial_count) {
+            return false;
+        }
+        d = (uint64_t) m_initial_count + 1;
+    }
+
+    m_next_time = m_initial_count_load_time + (d << m_count_shift);
+    m_timer_expiry = m_next_time;
+    return true;
+}
+
+void LocalApic::timer_update(int64_t current_time) {
+    if (next_timer(current_time)) {
+        libcpu_mod_timer_ns(m_timer, m_next_time);
+    } else {
+        libcpu_del_timer(m_timer);
+    }
+}
+
+uint32_t LocalApic::get_current_count() const {
+    if (!m_initial_count) {
+        return 0;
+    }
+
+    int64_t d = (libcpu_get_clock_ns(vm_clock) - m_initial_count_load_time) >> m_count_shift;
+
+    if (m_lvt[LVT_TIMER] & LVT_TIMER_PERIODIC) {
+        d = ((unsigned) d % ((uint64_t) m_initial_count + 1));
+    } else {
+        if (d >= m_initial_count) {
+            return 0;
+        }
+    }
+
+    return m_initial_count - d;
+}
+
+int LocalApic::register_read(int index, uint64_t &value) {
+    uint32_t val;
+    int ret = 0;
+
+    switch (index) {
+        case REG_ID:
+            if (is_x2apic_mode()) {
+                val = m_initial_apic_id;
+            } else {
+                val = m_id << 24;
+            }
+            break;
+        case REG_VERSION:
+            val = m_version | ((LVT_NB - 1) << 16);
+            break;
+        case REG_TPR:
+            val = m_tpr;
+            break;
+        case REG_APR:
+            val = get_arb_pri();
+            break;
+        case REG_PPR:
+            val = get_ppr();
+            break;
+        case REG_EOI:
+            val = 0;
+            break;
+        case REG_LDR:
+            if (is_x2apic_mode()) {
+                val = m_extended_log_dest;
+            } else {
+                val = m_log_dest << 24;
+            }
+            break;
+        case REG_DFR:
+            if (is_x2apic_mode()) {
+                val = 0;
+                ret = -1;
+            } else {
+                val = (m_dest_mode << 28) | 0xfffffff;
+            }
+            break;
+        case REG_SVR:
+            val = m_spurious_vec;
+            break;
+        case REG_ISR_BASE ... REG_ISR_BASE + 7:
+            val = m_isr[index & 7];
+            break;
+        case REG_TMR_BASE ... REG_TMR_BASE + 7:
+            val = m_tmr[index & 7];
+            break;
+        case REG_IRR_BASE ... REG_IRR_BASE + 7:
+            val = m_irr[index & 7];
+            break;
+        case REG_ESR:
+            val = m_esr;
+            break;
+        case REG_ICR_LO:
+        case REG_ICR_HI:
+            val = m_icr[index & 1];
+            break;
+        case REG_LVT_BASE ... REG_LVT_BASE + LVT_NB - 1:
+            val = m_lvt[index - REG_LVT_BASE];
+            break;
+        case REG_TIMER_ICR:
+            val = m_initial_count;
+            break;
+        case REG_TIMER_CCR:
+            val = get_current_count();
+            break;
+        case REG_TIMER_DCR:
+            val = m_divide_conf;
+            break;
+        default:
+            m_esr |= ESR_ILLEGAL_ADDRESS;
+            val = 0;
+            ret = -1;
+            break;
+    }
+
+    value = val;
+    return ret;
+}
+
+int LocalApic::register_write(int index, uint64_t value) {
+    switch (index) {
+        case REG_ID:
+            if (is_x2apic_mode()) {
+                return -1;
+            }
+            m_id = value >> 24;
+            break;
+        case REG_VERSION:
+            break;
+        case REG_TPR:
+            m_tpr = value;
+            update_irq();
+            break;
+        case REG_APR:
+        case REG_PPR:
+            break;
+        case REG_EOI:
+            eoi();
+            break;
+        case REG_LDR:
+            if (is_x2apic_mode()) {
+                return -1;
+            }
+            m_log_dest = value >> 24;
+            break;
+        case REG_DFR:
+            if (is_x2apic_mode()) {
+                return -1;
+            }
+            m_dest_mode = value >> 28;
+            break;
+        case REG_SVR:
+            m_spurious_vec = value & 0x1ff;
+            update_irq();
+            break;
+        case REG_ISR_BASE ... REG_ISR_BASE + 7:
+        case REG_TMR_BASE ... REG_TMR_BASE + 7:
+        case REG_IRR_BASE ... REG_IRR_BASE + 7:
+        case REG_ESR:
+            break;
+        case REG_ICR_LO: {
+            uint32_t dest;
+
+            m_icr[0] = value;
+            if (is_x2apic_mode()) {
+                m_icr[1] = value >> 32;
+                dest = m_icr[1];
+            } else {
+                dest = (m_icr[1] >> 24) & 0xff;
+            }
+
+            deliver_ipi(dest, (m_icr[0] >> 11) & 1, (m_icr[0] >> 8) & 7, m_icr[0] & 0xff, (m_icr[0] >> 15) & 1,
+                        (m_icr[0] >> 18) & 3);
+            break;
+        }
+        case REG_ICR_HI:
+            if (is_x2apic_mode()) {
+                return -1;
+            }
+            m_icr[1] = value;
+            break;
+        case REG_LVT_BASE ... REG_LVT_BASE + LVT_NB - 1: {
+            int n = index - REG_LVT_BASE;
+            m_lvt[n] = value;
+            if (n == LVT_TIMER) {
+                timer_update(libcpu_get_clock_ns(vm_clock));
+            }
+            break;
+        }
+        case REG_TIMER_ICR:
+            m_initial_count = value;
+            m_initial_count_load_time = libcpu_get_clock_ns(vm_clock);
+            timer_update(m_initial_count_load_time);
+            break;
+        case REG_TIMER_CCR:
+            break;
+        case REG_TIMER_DCR: {
+            m_divide_conf = value & 0xb;
+            int v = (m_divide_conf & 3) | ((m_divide_conf >> 1) & 4);
+            m_count_shift = (v + 1) & 7;
+            break;
+        }
+        case REG_SELF_IPI: {
+            if (!is_x2apic_mode()) {
+                return -1;
+            }
+            int vector = value & 0xff;
+            set_irq(vector, 0);
+            break;
+        }
+        default:
+            m_esr |= ESR_ILLEGAL_ADDRESS;
+            return -1;
+    }
+
+    return 0;
+}
+
+uint64_t LocalApic::mmio_read(uint64_t offset, unsigned size) {
+    if (size < 4) {
+        return 0;
+    }
+
+    if (!enabled()) {
+        printf("APIC MMIO read from offset %#" PRIx64 " ignored because APIC is disabled\n", offset);
+        return 0;
+    }
+
+    int index = (offset >> 4) & 0xff;
+    uint64_t value = 0;
+    register_read(index, value);
+    return value;
+}
+
+void LocalApic::mmio_write(uint64_t offset, uint64_t data, unsigned size) {
+    if (size < 4) {
+        return;
+    }
+
+    if (!enabled()) {
+        printf("APIC MMIO write to offset %#" PRIx64 " ignored because APIC is disabled\n", offset);
+        return;
+    }
+
+    int index = (offset >> 4) & 0xff;
+    if (!index) {
+        return;
+    }
+
+    register_write(index, data);
+}
+
+void LocalApic::deliver_ipi(uint32_t dest, uint8_t dest_mode, uint8_t delivery_mode, uint8_t vector,
+                            uint8_t trigger_mode, uint8_t dest_shorthand) {
+    bool deliver_to_self = false;
+
+    // Determine if this IPI should be delivered to self
+    switch (dest_shorthand) {
+        case 0: {
+            // No shorthand - check destination field
+            if (is_x2apic_mode()) {
+                deliver_to_self = (dest == m_initial_apic_id);
+            } else {
+                deliver_to_self = (dest == m_id);
+            }
+            break;
+        }
+        case 1:
+            // Self
+            deliver_to_self = true;
+            break;
+        case 2:
+            // All including self
+            deliver_to_self = true;
+            printf("lapic: IPI to all including self not fully implemented (treating as self)\n");
+            break;
+        case 3:
+            // All excluding self
+            printf("lapic: IPI to all excluding self not implemented\n");
+            return;
+    }
+
+    if (!deliver_to_self) {
+        // Destination is not this APIC
+        printf("lapic: IPI to other CPU not implemented (dest=%u)\n", dest);
+        return;
+    }
+
+    // Handle INIT level de-assert
+    if (delivery_mode == DM_INIT) {
+        int level = (m_icr[0] >> 14) & 1;
+        if (level == 0 && trigger_mode == 1) {
+            // INIT level de-assert - arbitration ID update, not needed for single CPU
+            return;
+        }
+        printf("lapic: INIT IPI not implemented\n");
+        return;
+    }
+
+    // Handle SIPI
+    if (delivery_mode == DM_SIPI) {
+        printf("lapic: SIPI not implemented\n");
+        return;
+    }
+
+    // Deliver to self
+    switch (delivery_mode) {
+        case DM_FIXED:
+        case DM_LOWPRI:
+            set_irq(vector, trigger_mode);
+            break;
+        case DM_SMI:
+            m_cpu_interrupt(CPU_INTERRUPT_SMI, false);
+            break;
+        case DM_NMI:
+            m_cpu_interrupt(CPU_INTERRUPT_NMI, false);
+            break;
+        default:
+            break;
+    }
+}
+
+void LocalApic::deliver_msi(uint32_t addr_lo, uint32_t addr_hi, uint32_t data) {
+    int vector = data & 0xff;
+    int delivery_mode = (data >> 8) & 7;
+    int trigger_mode = (data >> 15) & 1;
+
+    switch (delivery_mode) {
+        case DM_FIXED:
+        case DM_LOWPRI:
+            set_irq(vector, trigger_mode);
+            break;
+        case DM_SMI:
+            m_cpu_interrupt(CPU_INTERRUPT_SMI, false);
+            break;
+        case DM_NMI:
+            m_cpu_interrupt(CPU_INTERRUPT_NMI, false);
+            break;
+        case DM_EXTINT:
+            m_cpu_interrupt(CPU_INTERRUPT_HARD, false);
+            break;
+        default:
+            break;
+    }
+}
+
+void LocalApic::set_lapic(const kvm_lapic_state *state) {
+    auto get = [&](int index) -> uint32_t {
+        uint32_t val;
+        memcpy(&val, &state->regs[index << 4], sizeof(val));
+        return val;
+    };
+
+    if (is_x2apic_mode()) {
+        m_initial_apic_id = get(REG_ID);
+    } else {
+        m_id = get(REG_ID) >> 24;
+    }
+
+    m_tpr = get(REG_TPR);
+
+    if (is_x2apic_mode()) {
+        m_extended_log_dest = get(REG_LDR);
+    } else {
+        m_log_dest = get(REG_LDR) >> 24;
+        m_dest_mode = get(REG_DFR) >> 28;
+    }
+
+    m_spurious_vec = get(REG_SVR);
+
+    for (int i = 0; i < 8; i++) {
+        m_isr[i] = get(REG_ISR_BASE + i);
+        m_tmr[i] = get(REG_TMR_BASE + i);
+        m_irr[i] = get(REG_IRR_BASE + i);
+    }
+
+    m_esr = get(REG_ESR);
+    m_icr[0] = get(REG_ICR_LO);
+    m_icr[1] = get(REG_ICR_HI);
+
+    for (int i = 0; i < LVT_NB; i++) {
+        m_lvt[i] = get(REG_LVT_BASE + i);
+    }
+
+    m_initial_count = get(REG_TIMER_ICR);
+
+    m_divide_conf = get(REG_TIMER_DCR) & 0xb;
+    int v = (m_divide_conf & 3) | ((m_divide_conf >> 1) & 4);
+    m_count_shift = (v + 1) & 7;
+
+    m_initial_count_load_time = libcpu_get_clock_ns(vm_clock);
+    timer_update(m_initial_count_load_time);
+    update_irq();
+}
+
+void LocalApic::get_lapic(kvm_lapic_state *state) const {
+    memset(state->regs, 0, sizeof(state->regs));
+
+    auto put = [&](int index, uint32_t val) { memcpy(&state->regs[index << 4], &val, sizeof(val)); };
+
+    if (is_x2apic_mode()) {
+        put(REG_ID, m_initial_apic_id);
+    } else {
+        put(REG_ID, m_id << 24);
+    }
+
+    put(REG_VERSION, m_version | ((LVT_NB - 1) << 16));
+    put(REG_TPR, m_tpr);
+    put(REG_APR, get_arb_pri());
+    put(REG_PPR, get_ppr());
+
+    if (is_x2apic_mode()) {
+        put(REG_LDR, m_extended_log_dest);
+    } else {
+        put(REG_LDR, m_log_dest << 24);
+        put(REG_DFR, (m_dest_mode << 28) | 0xfffffff);
+    }
+
+    put(REG_SVR, m_spurious_vec);
+
+    for (int i = 0; i < 8; i++) {
+        put(REG_ISR_BASE + i, m_isr[i]);
+        put(REG_TMR_BASE + i, m_tmr[i]);
+        put(REG_IRR_BASE + i, m_irr[i]);
+    }
+
+    put(REG_ESR, m_esr);
+    put(REG_ICR_LO, m_icr[0]);
+    put(REG_ICR_HI, m_icr[1]);
+
+    for (int i = 0; i < LVT_NB; i++) {
+        put(REG_LVT_BASE + i, m_lvt[i]);
+    }
+
+    put(REG_TIMER_ICR, m_initial_count);
+    put(REG_TIMER_CCR, get_current_count());
+    put(REG_TIMER_DCR, m_divide_conf);
+}
+
+} // namespace kvm
+} // namespace s2e

--- a/libs2e/src/hw/lapic.h
+++ b/libs2e/src/hw/lapic.h
@@ -1,0 +1,169 @@
+///
+/// Copyright (C) 2026, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#ifndef S2E_KVM_LAPIC_H
+#define S2E_KVM_LAPIC_H
+
+#include <array>
+#include <cstdint>
+#include <functional>
+
+#include "device.h"
+
+struct CPUTimer;
+
+namespace s2e {
+namespace kvm {
+
+class LocalApic : public VirtualDevice {
+public:
+    static constexpr uint64_t APIC_SIZE = 0x1000;
+    static constexpr uint64_t APIC_DEFAULT_BASE = 0xfee00000;
+
+    static constexpr int LVT_TIMER = 0;
+    static constexpr int LVT_THERMAL = 1;
+    static constexpr int LVT_PERFORM = 2;
+    static constexpr int LVT_LINT0 = 3;
+    static constexpr int LVT_LINT1 = 4;
+    static constexpr int LVT_ERROR = 5;
+    static constexpr int LVT_NB = 6;
+
+    static constexpr int DM_FIXED = 0;
+    static constexpr int DM_LOWPRI = 1;
+    static constexpr int DM_SMI = 2;
+    static constexpr int DM_NMI = 4;
+    static constexpr int DM_INIT = 5;
+    static constexpr int DM_SIPI = 6;
+    static constexpr int DM_EXTINT = 7;
+
+    static constexpr uint32_t APIC_SV_DIRECTED_IO = (1 << 12);
+
+    // APIC register indices (byte offset >> 4)
+    static constexpr int REG_ID = 0x02;
+    static constexpr int REG_VERSION = 0x03;
+    static constexpr int REG_TPR = 0x08;
+    static constexpr int REG_APR = 0x09;
+    static constexpr int REG_PPR = 0x0a;
+    static constexpr int REG_EOI = 0x0b;
+    static constexpr int REG_LDR = 0x0d;
+    static constexpr int REG_DFR = 0x0e;
+    static constexpr int REG_SVR = 0x0f;
+    static constexpr int REG_ISR_BASE = 0x10;
+    static constexpr int REG_TMR_BASE = 0x18;
+    static constexpr int REG_IRR_BASE = 0x20;
+    static constexpr int REG_ESR = 0x28;
+    static constexpr int REG_ICR_LO = 0x30;
+    static constexpr int REG_ICR_HI = 0x31;
+    static constexpr int REG_LVT_BASE = 0x32;
+    static constexpr int REG_TIMER_ICR = 0x38;
+    static constexpr int REG_TIMER_CCR = 0x39;
+    static constexpr int REG_TIMER_DCR = 0x3e;
+    static constexpr int REG_SELF_IPI = 0x3f;
+
+    using CpuInterruptFn = std::function<void(int mask, bool reset)>;
+    using CpuExitFn = std::function<void(void)>;
+
+    LocalApic(uint64_t phys_base, CpuInterruptFn cpu_interrupt, CpuExitFn cpu_exit);
+    ~LocalApic() override;
+
+    uint64_t mmio_read(uint64_t offset, unsigned size) override;
+    void mmio_write(uint64_t offset, uint64_t data, unsigned size) override;
+
+    int get_interrupt();
+    void deliver_msi(uint32_t addr_lo, uint32_t addr_hi, uint32_t data);
+    void get_lapic(kvm_lapic_state *state) const;
+    void set_lapic(const kvm_lapic_state *state);
+
+    uint8_t get_tpr() const {
+        return m_tpr;
+    }
+    void set_tpr(uint8_t val);
+
+    uint64_t get_apic_base() const {
+        return m_apic_base;
+    }
+
+    void set_apic_base(uint64_t val);
+
+    void set_irq(int vector_num, int trigger_mode);
+
+private:
+    uint64_t m_apic_base = 0;
+    uint8_t m_id = 0;
+    uint32_t m_initial_apic_id = 0;
+    uint8_t m_version = 0;
+    uint8_t m_tpr = 0;
+    uint32_t m_spurious_vec = 0;
+    uint8_t m_log_dest = 0;
+    uint8_t m_dest_mode = 0;
+    uint32_t m_extended_log_dest = 0;
+
+    std::array<uint32_t, 8> m_isr = {};
+    std::array<uint32_t, 8> m_tmr = {};
+    std::array<uint32_t, 8> m_irr = {};
+    std::array<uint32_t, LVT_NB> m_lvt = {};
+    uint32_t m_esr = 0;
+    std::array<uint32_t, 2> m_icr = {};
+
+    uint32_t m_divide_conf = 0;
+    int m_count_shift = 0;
+    uint32_t m_initial_count = 0;
+
+    CPUTimer *m_timer = nullptr;
+    int64_t m_initial_count_load_time = 0;
+    int64_t m_next_time = 0;
+    int64_t m_timer_expiry = -1;
+
+    CpuInterruptFn m_cpu_interrupt;
+    CpuExitFn m_cpu_exit;
+
+    int register_read(int index, uint64_t &value);
+    int register_write(int index, uint64_t value);
+    void update_irq();
+    void deliver_ipi(uint32_t dest, uint8_t dest_mode, uint8_t delivery_mode, uint8_t vector, uint8_t trigger_mode,
+                     uint8_t dest_shorthand);
+
+    bool is_x2apic_mode() const;
+    int get_ppr() const;
+    int get_arb_pri() const;
+    void eoi();
+    void ioapic_eoi_broadcast(int vector);
+
+    static void timer_callback(void *opaque);
+    void on_timer();
+    void timer_update(int64_t current_time);
+    bool next_timer(int64_t current_time);
+    uint32_t get_current_count() const;
+    void local_deliver(int vector);
+    int irq_pending() const;
+    bool enabled() const;
+
+    static void set_bit(uint32_t *tab, int index);
+    static int get_bit(const uint32_t *tab, int index);
+    static void reset_bit(uint32_t *tab, int index);
+    static int get_highest_priority_int(const uint32_t *tab);
+};
+
+} // namespace kvm
+} // namespace s2e
+
+#endif

--- a/libs2e/src/s2e-kvm-io.cpp
+++ b/libs2e/src/s2e-kvm-io.cpp
@@ -20,6 +20,8 @@
 /// SOFTWARE.
 ///
 
+#include <unistd.h>
+
 #include <coroutine.h>
 #include <cpu/ioport.h>
 #include <cpu/kvm.h>
@@ -31,6 +33,7 @@
 #include <cpu/i386/cpu.h>
 #include <tcg/utils/log.h>
 #include "s2e-kvm-vcpu.h"
+#include "s2e-kvm-vm.h"
 #include "s2e-kvm.h"
 
 extern CPUX86State *env;
@@ -45,6 +48,14 @@ extern CPUX86State *env;
 
 namespace s2e {
 namespace kvm {
+
+static void signal_ioeventfd(int fd) {
+    uint64_t val = 1;
+    ssize_t ret = write(fd, &val, sizeof(val));
+    if (ret != sizeof(val)) {
+        fprintf(stderr, "ioeventfd: write to fd %d failed\n", fd);
+    }
+}
 
 // This is an experimental feature
 // #define ENABLE_RETRANSLATE
@@ -143,6 +154,12 @@ uint64_t s2e_kvm_mmio_read(target_phys_addr_t addr, unsigned size) {
 }
 
 void s2e_kvm_mmio_write(target_phys_addr_t addr, uint64_t data, unsigned size) {
+    int efd = g_s2e_kvm->vm()->lookupIoEventFd(false, addr, data, size);
+    if (efd >= 0) {
+        signal_ioeventfd(efd);
+        return;
+    }
+
     if (g_s2e_kvm->vm()->dev_mgr().mmio_write(addr, data, size)) {
         return;
     }
@@ -244,6 +261,12 @@ uint64_t s2e_kvm_ioport_read(pio_addr_t addr, unsigned size) {
 }
 
 void s2e_kvm_ioport_write(pio_addr_t addr, uint64_t data, unsigned size) {
+    int efd = g_s2e_kvm->vm()->lookupIoEventFd(true, addr, data, size);
+    if (efd >= 0) {
+        signal_ioeventfd(efd);
+        return;
+    }
+
     ++g_stats.io_writes;
 
     g_kvm_vcpu_buffer->exit_reason = KVM_EXIT_IO;

--- a/libs2e/src/s2e-kvm-io.cpp
+++ b/libs2e/src/s2e-kvm-io.cpp
@@ -32,6 +32,7 @@
 #include <cpu/exec.h>
 #include <cpu/i386/cpu.h>
 #include <tcg/utils/log.h>
+#include "hw/lapic.h"
 #include "s2e-kvm-vcpu.h"
 #include "s2e-kvm-vm.h"
 #include "s2e-kvm.h"
@@ -304,22 +305,40 @@ void s2e_kvm_ioport_write(pio_addr_t addr, uint64_t data, unsigned size) {
 
 static uint64_t s2e_apic_get_base(CPUX86State *env) {
     auto vcpu = VCPU::current();
+    if (auto lapic = vcpu->lapic()) {
+        return lapic->get_apic_base();
+    }
     return vcpu->vapic().get_apic_base();
 }
 
 static void s2e_apic_set_base(CPUX86State *env, uint64_t new_base) {
     auto vcpu = VCPU::current();
-    vcpu->vapic().set_apic_base(new_base);
+    if (auto lapic = vcpu->lapic()) {
+        lapic->set_apic_base(new_base);
+        if (!g_s2e_kvm->vm()->dev_mgr().rebase_device(new_base & ~0xfffULL, lapic)) {
+            fprintf(stderr, "Failed to rebase LAPIC to %#" PRIx64 "\n", new_base);
+            abort();
+        }
+    } else {
+        vcpu->vapic().set_apic_base(new_base);
+    }
 }
 
 static uint64_t s2e_apic_get_tpr(CPUX86State *env) {
     auto vcpu = VCPU::current();
+    if (auto lapic = vcpu->lapic()) {
+        return lapic->get_tpr();
+    }
     return vcpu->vapic().get_tpr();
 }
 
 static void s2e_apic_set_tpr(CPUX86State *env, uint64_t new_tpr) {
     auto vcpu = VCPU::current();
-    vcpu->vapic().set_tpr(new_tpr);
+    if (auto lapic = vcpu->lapic()) {
+        lapic->set_tpr(new_tpr);
+    } else {
+        vcpu->vapic().set_tpr(new_tpr);
+    }
 }
 
 struct cpu_io_funcs_t g_io = {

--- a/libs2e/src/s2e-kvm-io.cpp
+++ b/libs2e/src/s2e-kvm-io.cpp
@@ -39,14 +39,6 @@
 
 extern CPUX86State *env;
 
-#if 0
-#define SE_KVM_DEBUG_MMIO
-#define SE_KVM_DEBUG_APIC
-#define SE_KVM_DEBUG_IO
-
-#define DPRINTF(...) fprintf(logfile, __VA_ARGS__)
-#endif
-
 namespace s2e {
 namespace kvm {
 
@@ -141,16 +133,7 @@ uint64_t s2e_kvm_mmio_read(target_phys_addr_t addr, unsigned size) {
         }
     }
 
-#ifdef SE_KVM_DEBUG_MMIO
-    unsigned print_addr = 0;
-#ifdef SE_KVM_DEBUG_APIC
-    if (addr >= 0xf0000000)
-        print_addr = 1;
-#endif
-    if (print_addr) {
-        DPRINTF("mmior%d[%" PRIx64 "]=%" PRIx64 "\n", size, (uint64_t) addr, ret);
-    }
-#endif
+    libcpu_log_mask(CPU_LOG_KVM_IO, "mmior%d[%" PRIx64 "]=%" PRIx64 "\n", size, (uint64_t) addr, ret);
     return ret;
 }
 
@@ -174,17 +157,7 @@ void s2e_kvm_mmio_write(target_phys_addr_t addr, uint64_t data, unsigned size) {
 
     uint8_t *dataptr = g_kvm_vcpu_buffer->mmio.data;
 
-#ifdef SE_KVM_DEBUG_MMIO
-    unsigned print_addr = 0;
-#ifdef SE_KVM_DEBUG_APIC
-    if (addr >= 0xf0000000)
-        print_addr = 1;
-#endif
-
-    if (print_addr) {
-        DPRINTF("mmiow%d[%" PRIx64 "]=%" PRIx64 "\n", size, (uint64_t) addr, data);
-    }
-#endif
+    libcpu_log_mask(CPU_LOG_KVM_IO, "mmiow%d[%" PRIx64 "]=%" PRIx64 "\n", size, (uint64_t) addr, data);
 
     switch (size) {
         case 1:
@@ -254,9 +227,7 @@ uint64_t s2e_kvm_ioport_read(pio_addr_t addr, unsigned size) {
             assert(false && "Can't get here");
     }
 
-#ifdef SE_KVM_DEBUG_IO
-    DPRINTF("ior%d[%#x]=0x%" PRIx64 "\n", size, addr, ret);
-#endif
+    libcpu_log_mask(CPU_LOG_KVM_IO, "ior%d[%#x]=0x%" PRIx64 "\n", size, addr, ret);
 
     return ret;
 }
@@ -296,9 +267,7 @@ void s2e_kvm_ioport_write(pio_addr_t addr, uint64_t data, unsigned size) {
             assert(false && "Can't get here");
     }
 
-#ifdef SE_KVM_DEBUG_IO
-    DPRINTF("iow%d[%#x]=0x%" PRIx64 "\n", size, addr, data);
-#endif
+    libcpu_log_mask(CPU_LOG_KVM_IO, "iow%d[%#x]=0x%" PRIx64 "\n", size, addr, data);
 
     coroutine_yield();
 }

--- a/libs2e/src/s2e-kvm-trace.cpp
+++ b/libs2e/src/s2e-kvm-trace.cpp
@@ -99,6 +99,7 @@ int KVMTrace::sys_ioctl(int fd, int request, uint64_t arg1) {
                 case KVM_CAP_NR_VCPUS:
                 case KVM_CAP_MAX_VCPUS:
                 case KVM_CAP_JOIN_MEMORY_REGIONS_WORKS:
+                case KVM_CAP_IOEVENTFD:
                     // case KVM_CAP_READONLY_MEM:
                     ret = 1;
                     break;

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -41,6 +41,7 @@
 
 #if 0
 #define SE_KVM_DEBUG_IRQ
+#define DEBUG_LOCKS
 
 #define DPRINTF(...) fprintf(logfile, __VA_ARGS__)
 #else
@@ -158,24 +159,36 @@ void VCPU::create_lapic() {
 }
 
 int VCPU::initCpuLock(void) {
-    int ret = pthread_mutex_init(&m_cpuLock, nullptr);
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+
+#if DEBUG_LOCKS
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+#endif
+
+    int ret = pthread_mutex_init(&m_cpuLock, &attr);
     if (ret < 0) {
         fprintf(stderr, "Could not init cpu lock\n");
     }
 
+    pthread_mutexattr_destroy(&attr);
     return ret;
 }
 
 void VCPU::lock() {
-    pthread_mutex_lock(&m_cpuLock);
-}
-
-void VCPU::tryLock() {
-    pthread_mutex_trylock(&m_cpuLock);
+    auto ret = pthread_mutex_lock(&m_cpuLock);
+    if (ret != 0) {
+        fprintf(stderr, "Could not lock cpu: %d\n", ret);
+        abort();
+    }
 }
 
 void VCPU::unlock() {
-    pthread_mutex_unlock(&m_cpuLock);
+    auto ret = pthread_mutex_unlock(&m_cpuLock);
+    if (ret != 0) {
+        fprintf(stderr, "Could not unlock cpu: %d\n", ret);
+        abort();
+    }
 }
 
 #ifdef SE_KVM_DEBUG_CPUID

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -93,8 +93,6 @@ static VCPU *s_vcpu;
 // Default stack is a few megabytes, it's not enough.
 static const uint64_t S2E_STACK_SIZE = 1024 * 1024 * 1024;
 
-static const int CPU_EXIT_SIGNAL = SIGUSR2;
-
 VCPU::VCPU(std::shared_ptr<S2EKVM> &kvm, std::shared_ptr<VM> &vm, kvm_run *buffer) {
     s_vcpu = this;
     m_kvm = kvm;
@@ -106,7 +104,6 @@ VCPU::VCPU(std::shared_ptr<S2EKVM> &kvm, std::shared_ptr<VM> &vm, kvm_run *buffe
     tcg_register_thread();
 
     m_onExit = g_syscalls.onExit.connect(sigc::mem_fun(*this, &VCPU::requestProcessExit));
-    m_onSelect = g_syscalls.onSelect.connect(sigc::mem_fun(*this, &VCPU::requestExit));
 
     if (initCpuLock() < 0) {
         exit(-1);
@@ -134,7 +131,6 @@ VCPU::VCPU(std::shared_ptr<S2EKVM> &kvm, std::shared_ptr<VM> &vm, kvm_run *buffe
 
 VCPU::~VCPU() {
     m_onExit.disconnect();
-    m_onSelect.disconnect();
 }
 
 VCPU *VCPU::current() {
@@ -242,32 +238,6 @@ int VCPU::setCPUID2(kvm_cpuid2 *cpuid) {
     return 0;
 }
 
-void VCPU::cpuExitSignal(int signum) {
-    s_vcpu->m_env->kvm_request_interrupt_window = 1;
-    cpu_exit(s_vcpu->m_env);
-}
-
-void VCPU::initializeCpuExitSignal() {
-    struct sigaction act;
-    memset(&act, 0, sizeof(act));
-    sigfillset(&act.sa_mask);
-    act.sa_flags = 0;
-    act.sa_handler = cpuExitSignal;
-
-    if (sigaction(CPU_EXIT_SIGNAL, &act, NULL) < 0) {
-        perror("Could not initialize cpu exit signal");
-        exit(-1);
-    }
-
-    // The KVM client usually blocks all signals on the CPU thread.
-    // This interferes with our ability to exit the CPU loop, so we must unblock it.
-    union s2e_kvm_sigmask_t mask = m_sigmask;
-    sigaddset(&mask.sigset, CPU_EXIT_SIGNAL);
-    if (pthread_sigmask(SIG_UNBLOCK, &mask.sigset, NULL) < 0) {
-        abort();
-    }
-}
-
 // Defines which signals are blocked during execution of kvm.
 int VCPU::setSignalMask(kvm_signal_mask *mask) {
     // XXX: doesn't seem to matter for typical kvm clients,
@@ -324,7 +294,6 @@ int VCPU::run(int vcpu_fd) {
     }
 
     if (!m_cpuThreadInited) {
-        initializeCpuExitSignal();
         m_cpuThread = pthread_self();
         m_cpuThreadInited = true;
     }
@@ -503,64 +472,6 @@ void VCPU::cloneProcess(void) {
     coroutine_yield();
 
     m_cpuThread = pthread_self();
-}
-
-///
-/// \brief s2e_kvm_send_cpu_exit_signal sends a signal
-/// to the cpu loop thread in order to exit the cpu loop.
-///
-/// It is important to use a signal that executes on the
-/// same thread as the cpu loop in order to avoid race conditions
-/// and complex locking.
-///
-void VCPU::sendExitSignal() {
-    if (!m_cpuThreadInited) {
-        return;
-    }
-
-    if (pthread_kill(m_cpuThread, CPU_EXIT_SIGNAL) < 0) {
-        abort();
-    }
-}
-
-///
-/// \brief s2e_kvm_request_exit triggers an exit from the cpu loop
-///
-/// In vanilla KVM, the CPU stops executing guest code when there is
-/// an external event pending. Execution can stop at any instruction.
-///
-/// In our emulated KVM, stopping at any instruction is not possible
-/// because of TB chaining, threading, etc.
-///
-/// This may cause missed interrupts. The KVM client is ready to inject an interrupt,
-/// but cannot do so because kvm_run has not exited yet. While it is running,
-/// several interrupts of different priorities may be queued up. When kvm_run
-/// eventually returns, the highest priority interrupt is injected first.
-/// Because DBT is much slower than native execution, it often happens
-/// that lower priority don't get to run at all, and higher
-/// priority ones are missed.
-///
-/// Since we can't easily replicate KVM's behavior, we resort to doing
-/// what vanilla QEMU in DBT mode would do: interrupt the CPU loop when an interrupt
-/// is raised so that the interrupt is scheduled asap.
-///
-/// This requires adding an extra API to KVM. Things that have been tried
-/// to avoid adding the extra API, but did not work properly:
-/// - Intercept pthread_kill. KVM client may kick the CPU when an interrupt is ready.
-/// This is still too slow.
-/// - Intercept eventfd. KVM clients call poll eventfds instead of using signals.
-/// Polling for them from a separate thread didn't work either.
-///
-void VCPU::requestExit(void) {
-    if (!m_env) {
-        return;
-    }
-
-#ifdef SE_KVM_DEBUG_RUN
-    DPRINTF("s2e_kvm_request_exit\n");
-#endif
-
-    sendExitSignal();
 }
 
 void VCPU::request_exit_cpu_loop() {

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -25,6 +25,7 @@
 
 #include <cpu/exec.h>
 #include <cpu/i386/cpu.h>
+#include <cpu/kvm.h>
 #include <timer.h>
 
 #ifdef CONFIG_SYMBEX
@@ -50,6 +51,7 @@ extern "C" {
 void tcg_register_thread(void);
 }
 
+#include "hw/lapic.h"
 #include "s2e-kvm-vcpu.h"
 #include "syscalls.h"
 
@@ -129,6 +131,13 @@ std::shared_ptr<VCPU> VCPU::create(std::shared_ptr<S2EKVM> &kvm, std::shared_ptr
     }
 
     return std::shared_ptr<VCPU>(new VCPU(kvm, vm, buffer));
+}
+
+void VCPU::create_lapic() {
+    m_lapic = std::make_shared<LocalApic>(
+        LocalApic::APIC_DEFAULT_BASE, [this](int mask, bool reset) { interrupt(mask, reset); },
+        [this]() { request_exit_cpu_loop(); });
+    m_vm->dev_mgr().register_device(LocalApic::APIC_DEFAULT_BASE, LocalApic::APIC_SIZE, m_lapic);
 }
 
 int VCPU::initCpuLock(void) {
@@ -375,7 +384,8 @@ int VCPU::run(int vcpu_fd) {
     m_handlingKvmCallback =
         m_cpuBuffer->exit_reason == KVM_EXIT_IO || m_cpuBuffer->exit_reason == KVM_EXIT_MMIO ||
         m_cpuBuffer->exit_reason == KVM_EXIT_FLUSH_DISK || m_cpuBuffer->exit_reason == KVM_EXIT_SAVE_DEV_STATE ||
-        m_cpuBuffer->exit_reason == KVM_EXIT_RESTORE_DEV_STATE || m_cpuBuffer->exit_reason == KVM_EXIT_CLONE_PROCESS;
+        m_cpuBuffer->exit_reason == KVM_EXIT_RESTORE_DEV_STATE || m_cpuBuffer->exit_reason == KVM_EXIT_CLONE_PROCESS ||
+        m_cpuBuffer->exit_reason == KVM_EXIT_IOAPIC_EOI;
 
     // Might not be NULL if resuming from an interrupted I/O
     // assert(env->current_tb == NULL);
@@ -706,6 +716,16 @@ int VCPU::sys_ioctl(int fd, int request, uint64_t arg1) {
             ret = getMPState((kvm_mp_state *) arg1);
         } break;
 
+        case KVM_GET_LAPIC: {
+            m_lapic->get_lapic((kvm_lapic_state *) arg1);
+            ret = 0;
+        } break;
+
+        case KVM_SET_LAPIC: {
+            m_lapic->set_lapic((kvm_lapic_state *) arg1);
+            ret = 0;
+        } break;
+
         case KVM_GET_DEBUGREGS: {
             ret = getDebugRegs((kvm_debugregs *) arg1);
         } break;
@@ -721,6 +741,17 @@ int VCPU::sys_ioctl(int fd, int request, uint64_t arg1) {
 
         case KVM_NMI: {
             ret = nmi();
+        } break;
+
+        case KVM_SET_VAPIC_ADDR: {
+            const auto data = (kvm_vapic_addr *) arg1;
+            printf("Setting VAPIC address to %#" PRIx64 "\n", (uint64_t) data->vapic_addr);
+            if (auto lapic = this->lapic()) {
+                lapic->set_apic_base(data->vapic_addr);
+            } else {
+                m_vapic.set_apic_base(data->vapic_addr);
+            }
+            ret = 0;
         } break;
 
         default: {
@@ -743,6 +774,17 @@ void *VCPU::sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t 
 
 void VCPU::flushTlb() {
     tlb_flush(m_env, 1);
+}
+
+void VCPU::interrupt(int mask, bool reset) {
+    libcpu_log_mask(CPU_LOG_INT, "Interrupt: mask=%#x reset=%d\n", mask, reset);
+    cpu_exit(m_env);
+
+    if (reset) {
+        m_env->interrupt_request &= ~mask;
+    } else {
+        m_env->interrupt_request |= mask;
+    }
 }
 } // namespace kvm
 } // namespace s2e

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -49,6 +49,7 @@
 
 extern "C" {
 void tcg_register_thread(void);
+int cpu_get_pic_interrupt(CPUX86State *env);
 }
 
 #include "hw/lapic.h"
@@ -64,6 +65,22 @@ CPUX86State *g_cpu_env;
 
 // TODO: remove this global var from libcpu
 extern CPUX86State *env;
+
+int cpu_get_pic_interrupt(CPUX86State *env) {
+    if (env->kvm_irq >= 0) {
+        auto irq = env->kvm_irq;
+        env->kvm_irq = -1;
+        return irq;
+    }
+
+    auto vcpu = s2e::kvm::VCPU::current();
+    if (auto apic = vcpu->lapic()) {
+        return apic->get_interrupt();
+    }
+
+    libcpu_log_mask(CPU_LOG_INT, "Interrupt requested but LAPIC is not initialized\n");
+    abort();
+}
 
 namespace s2e {
 namespace kvm {
@@ -257,53 +274,17 @@ void VCPU::coroutineFcn(void *opaque) {
     CPUX86State *env = vcpu->m_env;
     auto buffer = vcpu->m_cpuBuffer;
 
-#ifdef SE_KVM_DEBUG_IRQ
-    static uint64_t prev_mflags = 0;
-#endif
-
     while (1) {
         libcpu_run_all_timers();
 
         assert(env->current_tb == NULL);
 
-        // XXX: need to save irq state on state switches
-        if (env->kvm_irq != -1) {
-            if (env->interrupt_request == 0) {
-                DPRINTF("Forcing IRQ\n");
-            }
-            env->interrupt_request |= CPU_INTERRUPT_HARD;
-
-#ifdef SE_KVM_DEBUG_IRQ
-            if (env->interrupt_request & CPU_INTERRUPT_HARD) {
-                DPRINTF("Handling IRQ %d req=%#x hflags=%x hflags2=%#x mflags=%#lx tpr=%#x esp=%#lx\n", env->kvm_irq,
-                        env->interrupt_request, env->hflags, env->hflags2, (uint64_t) env->mflags,
-                        vcpu->vapic().get_tpr(), (uint64_t) env->regs[R_ESP]);
-            }
-#endif
-        }
-
         env->kvm_request_interrupt_window |= buffer->request_interrupt_window;
-
-#ifdef SE_KVM_DEBUG_IRQ
-        prev_mflags = env->mflags;
-        uint64_t prev_eip = env->eip;
-#endif
 
         vcpu->m_cpuStateIsPrecise = false;
         env->exit_request = 0;
         cpu_x86_exec(env);
         vcpu->m_cpuStateIsPrecise = true;
-        // DPRINTF("cpu_exec return %#x\n", ret);
-
-#ifdef SE_KVM_DEBUG_IRQ
-        bool mflags_changed = (prev_mflags != env->mflags);
-        if (mflags_changed) {
-            DPRINTF("mflags changed: %lx old=%lx new=%lx reqwnd=%d peip=%lx, eip=%lx\n", (uint64_t) mflags_changed,
-                    (uint64_t) prev_mflags, (uint64_t) env->mflags, g_kvm_vcpu_buffer->request_interrupt_window,
-                    (uint64_t) prev_eip, (uint64_t) env->eip);
-        }
-        prev_mflags = env->mflags;
-#endif
 
         assert(env->current_tb == NULL);
 
@@ -444,18 +425,15 @@ int VCPU::run(int vcpu_fd) {
 }
 
 int VCPU::interrupt(kvm_interrupt *interrupt) {
-#ifdef SE_KVM_DEBUG_IRQ
-    DPRINTF("IRQ %d env->mflags=%lx hflags=%x hflags2=%x ptr=%#x\n", interrupt->irq, (uint64_t) env->mflags,
-            env->hflags, env->hflags2, m_vapic.get_tpr());
-    fflush(stdout);
-#endif
+    libcpu_log_mask(CPU_LOG_INT, "IRQ %d env->mflags=%lx hflags=%x hflags2=%x ptr=%#x\n", interrupt->irq,
+                    (uint64_t) env->mflags, env->hflags, env->hflags2, m_vapic.get_tpr());
 
     assert(!m_handlingKvmCallback);
     assert(!m_inKvmRun);
     assert(m_env->mflags & IF_MASK);
 
     if (m_env->interrupt_request & CPU_INTERRUPT_HARD) {
-        DPRINTF("Interrupt already pending, cannot inject IRQ %d\n", interrupt->irq);
+        libcpu_log_mask(CPU_LOG_INT, "Interrupt already pending, cannot inject IRQ %d\n", interrupt->irq);
         return -EEXIST;
     }
 

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -568,6 +568,10 @@ void VCPU::requestExit(void) {
     sendExitSignal();
 }
 
+void VCPU::request_exit_cpu_loop() {
+    cpu_exit(m_env);
+}
+
 ///
 /// \brief s2e_kvm_request_process_exit cleanly exits
 /// the process by sending it SIGTERM

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -498,10 +498,6 @@ void VCPU::cloneProcess(void) {
     coroutine_yield();
 
     m_cpuThread = pthread_self();
-
-    if (m_kvm->initTimerThread() < 0) {
-        exit(-1);
-    }
 }
 
 ///

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -754,6 +754,16 @@ int VCPU::sys_ioctl(int fd, int request, uint64_t arg1) {
             ret = 0;
         } break;
 
+        case KVM_GET_VCPU_EVENTS: {
+            printf("Not implemented KVM_GET_VCPU_EVENTS\n");
+            ret = 0;
+        } break;
+
+        case KVM_SET_VCPU_EVENTS: {
+            printf("Not implemented KVM_SET_VCPU_EVENTS\n");
+            ret = 0;
+        } break;
+
         default: {
             fprintf(stderr, "libs2e: unknown KVM VCPU IOCTL vcpu %d request=%#x arg=%#" PRIx64 " ret=%#x\n", fd,
                     request, arg1, ret);

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -764,6 +764,26 @@ int VCPU::sys_ioctl(int fd, int request, uint64_t arg1) {
             ret = 0;
         } break;
 
+        case KVM_GET_STATS_FD: {
+            printf("Not implemented KVM_GET_STATS_FD\n");
+            ret = open("/dev/null", O_RDWR);
+        } break;
+
+        case KVM_X86_SETUP_MCE: {
+            printf("Not implemented KVM_X86_SETUP_MCE\n");
+            ret = 0;
+        } break;
+
+        case KVM_TPR_ACCESS_REPORTING: {
+            const auto data = (kvm_tpr_access_ctl *) arg1;
+            if (data->enabled) {
+                printf("libs2e: KVM client requested TPR access reporting, but it's not implemented\n");
+                ret = -1;
+            } else {
+                ret = 0;
+            }
+        } break;
+
         default: {
             fprintf(stderr, "libs2e: unknown KVM VCPU IOCTL vcpu %d request=%#x arg=%#" PRIx64 " ret=%#x\n", fd,
                     request, arg1, ret);

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -288,6 +288,10 @@ void VCPU::coroutineFcn(void *opaque) {
     auto buffer = vcpu->m_cpuBuffer;
 
     while (1) {
+        if (!vcpu->m_task_runner.run_on_thread()) {
+            abort();
+        }
+
         libcpu_run_all_timers();
 
         assert(env->current_tb == NULL);

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -39,14 +39,8 @@
 #include <tcg/utils/bitops.h>
 #endif
 
-#if 0
-#define SE_KVM_DEBUG_IRQ
-#define DEBUG_LOCKS
-
-#define DPRINTF(...) fprintf(logfile, __VA_ARGS__)
-#else
-#define DPRINTF(...)
-#endif
+// #define SE_KVM_DEBUG_IRQ
+// #define DEBUG_LOCKS
 
 extern "C" {
 void tcg_register_thread(void);
@@ -79,7 +73,7 @@ int cpu_get_pic_interrupt(CPUX86State *env) {
         return apic->get_interrupt();
     }
 
-    libcpu_log_mask(CPU_LOG_INT, "Interrupt requested but LAPIC is not initialized\n");
+    libcpu_log_mask(CPU_LOG_KVM, "Interrupt requested but LAPIC is not initialized\n");
     abort();
 }
 
@@ -113,7 +107,7 @@ VCPU::VCPU(std::shared_ptr<S2EKVM> &kvm, std::shared_ptr<VM> &vm, kvm_run *buffe
     m_env = g_cpu_env = env = cpu_x86_init(&m_kvm->getCpuid());
 
     if (!m_env) {
-        DPRINTF("Could not create cpu\n");
+        libcpu_log_mask(CPU_LOG_KVM, "Could not create cpu\n");
         exit(-1);
     }
 
@@ -187,14 +181,6 @@ void VCPU::unlock() {
     }
 }
 
-#ifdef SE_KVM_DEBUG_CPUID
-static void print_cpuid2(struct kvm_cpuid_entry2 *e) {
-    DPRINTF("cpuid function=%#010" PRIx32 " index=%#010" PRIx32 " flags=%#010" PRIx32 " eax=%#010" PRIx32
-            " ebx=%#010" PRIx32 " ecx=%#010" PRIx32 " edx=%#010" PRIx32 "\n",
-            e->function, e->index, e->flags, e->eax, e->ebx, e->ecx, e->edx);
-}
-#endif
-
 int VCPU::getClock(kvm_clock_data *clock) {
     assert(false && "Not implemented");
 }
@@ -244,9 +230,7 @@ int VCPU::setSignalMask(kvm_signal_mask *mask) {
     // not sure what the implications of spurious signals are.
     m_sigmask_size = mask->len;
     for (unsigned i = 0; i < mask->len; ++i) {
-#ifdef SE_KVM_DEBUG_INTERFACE
-        DPRINTF("  signals %#04x\n", mask->sigset[i]);
-#endif
+        libcpu_log_mask(CPU_LOG_KVM, "  signals %#04x\n", mask->sigset[i]);
         m_sigmask.bytes[i] = mask->sigset[i];
     }
     return 0;
@@ -311,9 +295,7 @@ int VCPU::run(int vcpu_fd) {
                                                  m_cpuBuffer->if_flag && (m_env->kvm_irq == -1);
 
     if (m_cpuBuffer->ready_for_interrupt_injection) {
-#ifdef SE_KVM_DEBUG_IRQ
-        DPRINTF("%s early ret for ints\n", __FUNCTION__);
-#endif
+        libcpu_log_mask(CPU_LOG_KVM, "%s early ret for ints\n", __FUNCTION__);
         m_cpuBuffer->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN;
         return 0;
     }
@@ -322,12 +304,10 @@ int VCPU::run(int vcpu_fd) {
 
     m_inKvmRun = true;
 
-#ifdef SE_KVM_DEBUG_RUN
     if (!m_handlingKvmCallback) {
-        DPRINTF("%s riw=%d cr8=%#x\n", __FUNCTION__, g_kvm_vcpu_buffer->request_interrupt_window,
-                (unsigned) g_kvm_vcpu_buffer->cr8);
+        libcpu_log_mask(CPU_LOG_KVM, "%s riw=%d cr8=%#x\n", __FUNCTION__, g_kvm_vcpu_buffer->request_interrupt_window,
+                        (unsigned) g_kvm_vcpu_buffer->cr8);
     }
-#endif
 
     m_cpuBuffer->exit_reason = -1;
 
@@ -385,13 +365,11 @@ int VCPU::run(int vcpu_fd) {
 
     assert(m_cpuBuffer->exit_reason != 1);
 
-#ifdef SE_KVM_DEBUG_RUN
     if (!m_handlingKvmCallback) {
-        DPRINTF("%s riw=%d rii=%d er=%#x cr8=%#x\n", __FUNCTION__, g_kvm_vcpu_buffer->request_interrupt_window,
-                g_kvm_vcpu_buffer->ready_for_interrupt_injection, g_kvm_vcpu_buffer->exit_reason,
-                (unsigned) g_kvm_vcpu_buffer->cr8);
+        libcpu_log_mask(CPU_LOG_KVM, "%s riw=%d rii=%d er=%#x cr8=%#x\n", __FUNCTION__,
+                        g_kvm_vcpu_buffer->request_interrupt_window, g_kvm_vcpu_buffer->ready_for_interrupt_injection,
+                        g_kvm_vcpu_buffer->exit_reason, (unsigned) g_kvm_vcpu_buffer->cr8);
     }
-#endif
 
     if (m_cpuBuffer->exit_reason == KVM_EXIT_INTR) {
         // This must be set at the very end, because syscalls might
@@ -411,7 +389,7 @@ int VCPU::run(int vcpu_fd) {
 }
 
 int VCPU::interrupt(kvm_interrupt *interrupt) {
-    libcpu_log_mask(CPU_LOG_INT, "IRQ %d env->mflags=%lx hflags=%x hflags2=%x ptr=%#x\n", interrupt->irq,
+    libcpu_log_mask(CPU_LOG_KVM, "IRQ %d env->mflags=%lx hflags=%x hflags2=%x ptr=%#x\n", interrupt->irq,
                     (uint64_t) env->mflags, env->hflags, env->hflags2, m_vapic.get_tpr());
 
     assert(!m_handlingKvmCallback);
@@ -419,7 +397,7 @@ int VCPU::interrupt(kvm_interrupt *interrupt) {
     assert(m_env->mflags & IF_MASK);
 
     if (m_env->interrupt_request & CPU_INTERRUPT_HARD) {
-        libcpu_log_mask(CPU_LOG_INT, "Interrupt already pending, cannot inject IRQ %d\n", interrupt->irq);
+        libcpu_log_mask(CPU_LOG_KVM, "Interrupt already pending, cannot inject IRQ %d\n", interrupt->irq);
         return -EEXIST;
     }
 
@@ -557,6 +535,7 @@ int VCPU::sys_ioctl(int fd, int request, uint64_t arg1) {
             if (m_handlingDeviceState) {
                 ret = 0;
             } else {
+                libcpu_log_mask(CPU_LOG_KVM, "set_xsave\n");
                 ret = setXSAVE((kvm_xsave *) arg1);
             }
         } break;
@@ -655,7 +634,7 @@ int VCPU::sys_ioctl(int fd, int request, uint64_t arg1) {
 
         case KVM_SET_VAPIC_ADDR: {
             const auto data = (kvm_vapic_addr *) arg1;
-            printf("Setting VAPIC address to %#" PRIx64 "\n", (uint64_t) data->vapic_addr);
+            libcpu_log_mask(CPU_LOG_KVM, "Setting VAPIC address to %#" PRIx64 "\n", (uint64_t) data->vapic_addr);
             if (auto lapic = this->lapic()) {
                 lapic->set_apic_base(data->vapic_addr);
             } else {
@@ -665,22 +644,22 @@ int VCPU::sys_ioctl(int fd, int request, uint64_t arg1) {
         } break;
 
         case KVM_GET_VCPU_EVENTS: {
-            printf("Not implemented KVM_GET_VCPU_EVENTS\n");
+            libcpu_log_mask(CPU_LOG_KVM, "Not implemented KVM_GET_VCPU_EVENTS\n");
             ret = 0;
         } break;
 
         case KVM_SET_VCPU_EVENTS: {
-            printf("Not implemented KVM_SET_VCPU_EVENTS\n");
+            libcpu_log_mask(CPU_LOG_KVM, "Not implemented KVM_SET_VCPU_EVENTS\n");
             ret = 0;
         } break;
 
         case KVM_GET_STATS_FD: {
-            printf("Not implemented KVM_GET_STATS_FD\n");
+            libcpu_log_mask(CPU_LOG_KVM, "Not implemented KVM_GET_STATS_FD\n");
             ret = open("/dev/null", O_RDWR);
         } break;
 
         case KVM_X86_SETUP_MCE: {
-            printf("Not implemented KVM_X86_SETUP_MCE\n");
+            libcpu_log_mask(CPU_LOG_KVM, "Not implemented KVM_X86_SETUP_MCE\n");
             ret = 0;
         } break;
 
@@ -717,7 +696,10 @@ void VCPU::flushTlb() {
 }
 
 void VCPU::interrupt(int mask, bool reset) {
-    libcpu_log_mask(CPU_LOG_INT, "Interrupt: mask=%#x reset=%d\n", mask, reset);
+#ifdef CONFIG_SYMBEX
+    libcpu_log_mask(CPU_LOG_KVM, "interrupt: mask=%#x reset=%d scale=%d\n", mask, reset,
+                    *g_sqi.exec.clock_scaling_factor);
+#endif
     cpu_exit(m_env);
 
     if (reset) {

--- a/libs2e/src/s2e-kvm-vcpu.cpp
+++ b/libs2e/src/s2e-kvm-vcpu.cpp
@@ -253,7 +253,6 @@ void VCPU::coroutineFcn(void *opaque) {
         env->kvm_request_interrupt_window |= buffer->request_interrupt_window;
 
         vcpu->m_cpuStateIsPrecise = false;
-        env->exit_request = 0;
         cpu_x86_exec(env);
         vcpu->m_cpuStateIsPrecise = true;
 

--- a/libs2e/src/s2e-kvm-vcpu.h
+++ b/libs2e/src/s2e-kvm-vcpu.h
@@ -37,6 +37,7 @@
 #include "FileDescriptorManager.h"
 #include "hw/vapic.h"
 #include "syscalls.h"
+#include "task_runner.h"
 
 namespace s2e {
 namespace kvm {
@@ -51,6 +52,8 @@ private:
     std::shared_ptr<S2EKVM> m_kvm;
     std::shared_ptr<VM> m_vm;
     std::shared_ptr<LocalApic> m_lapic;
+
+    TaskRunner m_task_runner;
 
     int m_fd = -1;
 
@@ -199,6 +202,10 @@ public:
     }
     const VirtualApic &vapic() const {
         return m_vapic;
+    }
+
+    TaskRunner &task_runner() {
+        return m_task_runner;
     }
 
     void flushTlb();

--- a/libs2e/src/s2e-kvm-vcpu.h
+++ b/libs2e/src/s2e-kvm-vcpu.h
@@ -41,6 +41,8 @@
 namespace s2e {
 namespace kvm {
 
+class LocalApic;
+
 // TODO: remove this global var
 extern kvm_run *g_kvm_vcpu_buffer;
 
@@ -48,6 +50,7 @@ class VCPU : public IFile {
 private:
     std::shared_ptr<S2EKVM> m_kvm;
     std::shared_ptr<VM> m_vm;
+    std::shared_ptr<LocalApic> m_lapic;
 
     int m_fd = -1;
 
@@ -168,6 +171,8 @@ public:
     static std::shared_ptr<VCPU> create(std::shared_ptr<S2EKVM> &kvm, std::shared_ptr<VM> &vm);
     static VCPU *current();
 
+    void create_lapic();
+
     void lock();
     void tryLock();
     void unlock();
@@ -179,6 +184,11 @@ public:
     void saveDeviceState(void);
     void restoreDeviceState(void);
     void cloneProcess(void);
+    void interrupt(int mask, bool reset);
+
+    std::shared_ptr<LocalApic> lapic() const {
+        return m_lapic;
+    }
 
     inline bool inKvmRun() const {
         return m_inKvmRun;

--- a/libs2e/src/s2e-kvm-vcpu.h
+++ b/libs2e/src/s2e-kvm-vcpu.h
@@ -174,7 +174,6 @@ public:
     void create_lapic();
 
     void lock();
-    void tryLock();
     void unlock();
 
     void sendExitSignal();

--- a/libs2e/src/s2e-kvm-vcpu.h
+++ b/libs2e/src/s2e-kvm-vcpu.h
@@ -92,10 +92,6 @@ private:
     volatile bool m_inKvmRun = false;
 
     fsigc::connection m_onExit;
-    fsigc::connection m_onSelect;
-
-    static void cpuExitSignal(int signum);
-    void initializeCpuExitSignal();
 
     static void setCpuSegment(SegmentCache *libcpu_seg, const kvm_segment *kvm_seg);
     static void getCpuSegment(kvm_segment *kvm_seg, const SegmentCache *libcpu_seg);
@@ -178,9 +174,6 @@ public:
 
     void lock();
     void unlock();
-
-    void sendExitSignal();
-    void requestExit(void);
 
     void flushDisk(void);
     void saveDeviceState(void);

--- a/libs2e/src/s2e-kvm-vcpu.h
+++ b/libs2e/src/s2e-kvm-vcpu.h
@@ -185,6 +185,7 @@ public:
     void restoreDeviceState(void);
     void cloneProcess(void);
     void interrupt(int mask, bool reset);
+    void request_exit_cpu_loop();
 
     std::shared_ptr<LocalApic> lapic() const {
         return m_lapic;

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -81,6 +81,10 @@ void VM::sendCpuExitSignal() {
 
 int VM::enableCapability(kvm_enable_cap *cap) {
     switch (cap->cap) {
+        case KVM_CAP_MAX_VCPU_ID:
+            printf("KVM_CAP_MAX_VCPU_ID=%d\n", (int) cap->args[0]);
+            m_maxVcpuId = (int) cap->args[0];
+            return 0;
         case KVM_CAP_SPLIT_IRQCHIP: {
             printf("KVM_CAP_SPLIT_IRQCHIP=%d\n", (int) cap->args[0]);
             m_split_irqchip = true;

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -143,7 +143,7 @@ int VM::setTSSAddress(uint64_t tss_addr) {
 }
 
 int VM::setUserMemoryRegion(kvm_userspace_memory_region *region) {
-    m_cpu->requestExit();
+    m_cpu->request_exit_cpu_loop();
 
     m_cpu->lock();
 
@@ -167,7 +167,7 @@ int VM::memoryReadWrite(kvm_mem_rw *mem) {
     }
 #endif
 
-    m_cpu->requestExit();
+    m_cpu->request_exit_cpu_loop();
     m_cpu->lock();
     cpu_host_memory_rw(mem->source, mem->dest, mem->length, mem->is_write);
     m_cpu->unlock();
@@ -182,7 +182,7 @@ int VM::registerFixedRegion(kvm_fixed_region *region) {
 }
 
 int VM::getDirtyLog(kvm_dirty_log *log) {
-    m_cpu->requestExit();
+    m_cpu->request_exit_cpu_loop();
 
     const MemoryDesc *r = mem_desc_get_slot(log->slot);
 
@@ -410,7 +410,7 @@ int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
         } break;
 
         case KVM_FORCE_EXIT: {
-            m_cpu->requestExit();
+            m_cpu->request_exit_cpu_loop();
             ret = 0;
         } break;
 

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -200,7 +200,7 @@ int VM::getDirtyLog(kvm_dirty_log *log) {
         return 0;
     }
 
-    m_cpu->tryLock();
+    m_cpu->lock();
 
     cpu_physical_memory_get_dirty_bitmap((uint8_t *) log->dirty_bitmap, r->ram_addr, r->kvm.memory_size,
                                          VGA_DIRTY_FLAG);

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -41,6 +41,7 @@
 #include <tcg/tcg-llvm.h>
 #endif
 
+#include "hw/lapic.h"
 #include "libs2e.h"
 #include "s2e-kvm-vcpu.h"
 #include "s2e-kvm-vm.h"
@@ -79,9 +80,17 @@ void VM::sendCpuExitSignal() {
 }
 
 int VM::enableCapability(kvm_enable_cap *cap) {
-    printf("Enable capability not supported %d\n", cap->cap);
-    errno = 1;
-    return -1;
+    switch (cap->cap) {
+        case KVM_CAP_SPLIT_IRQCHIP: {
+            printf("KVM_CAP_SPLIT_IRQCHIP=%d\n", (int) cap->args[0]);
+            m_split_irqchip = true;
+            return 0;
+        }
+        default:
+            printf("Enable capability not supported %d\n", cap->cap);
+            errno = 1;
+            return -1;
+    }
 }
 
 int VM::createVirtualCPU() {
@@ -99,6 +108,10 @@ int VM::createVirtualCPU() {
     }
 
     m_cpu = vcpu;
+
+    if (m_split_irqchip) {
+        m_cpu->create_lapic();
+    }
 
     return g_fdm->registerInterface(vcpu);
 }

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -73,12 +73,6 @@ std::shared_ptr<VM> VM::create(std::shared_ptr<S2EKVM> &kvm) {
     return ret;
 }
 
-void VM::sendCpuExitSignal() {
-    if (m_cpu) {
-        m_cpu->sendExitSignal();
-    }
-}
-
 int VM::enableCapability(kvm_enable_cap *cap) {
     switch (cap->cap) {
         case KVM_CAP_MAX_VCPU_ID:

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -332,6 +332,37 @@ int VM::set_gsi_routing(const kvm_irq_routing *routing) {
     return 0;
 }
 
+int VM::irq_line(const kvm_irq_level *level) {
+    uint32_t gsi = level->irq;
+
+    libcpu_log_mask(CPU_LOG_INT, "KVM_IRQ_LINE gsi=%d level=%d\n", gsi, level->level);
+
+    if (!level->level) {
+        return 0;
+    }
+
+    if (!m_cpu || !m_cpu->lapic()) {
+        fprintf(stderr, "libs2e: KVM_IRQ_LINE gsi=%d but no LAPIC configured\n", gsi);
+        return -1;
+    }
+
+    auto it = m_gsi_routes.find(gsi);
+    if (it == m_gsi_routes.end()) {
+        return 0;
+    }
+
+    auto lapic = m_cpu->lapic();
+    for (const auto &entry : it->second) {
+        if (entry.type == KVM_IRQ_ROUTING_MSI) {
+            lapic->deliver_msi(entry.u.msi.address_lo, entry.u.msi.address_hi, entry.u.msi.data);
+        } else {
+            fprintf(stderr, "libs2e: KVM_IRQ_LINE gsi=%d unsupported routing type %d\n", gsi, entry.type);
+        }
+    }
+
+    return 0;
+}
+
 int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
     int ret = -1;
     switch ((uint32_t) request) {
@@ -409,6 +440,18 @@ int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
 
         case KVM_SET_GSI_ROUTING: {
             ret = set_gsi_routing((const kvm_irq_routing *) arg1);
+        } break;
+
+        case KVM_IRQ_LINE: {
+            m_cpu->request_exit_cpu_loop();
+            m_cpu->lock();
+            ret = irq_line((const kvm_irq_level *) arg1);
+            m_cpu->unlock();
+        } break;
+
+        case KVM_CREATE_IRQCHIP: {
+            printf("Not implemented KVM_CREATE_IRQCHIP\n");
+            ret = 0;
         } break;
 
         default: {

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -103,6 +103,27 @@ int VM::createVirtualCPU() {
     return g_fdm->registerInterface(vcpu);
 }
 
+int VM::lookupIoEventFd(bool is_pio, uint64_t addr, uint64_t data, unsigned size) {
+    const auto &events = is_pio ? m_ioeventfds_pio : m_ioeventfds_mmio;
+
+    for (const auto &entry : events) {
+        if (entry.addr != addr) {
+            continue;
+        }
+        if (entry.len != 0 && entry.len != size) {
+            continue;
+        }
+        if (entry.has_datamatch) {
+            uint64_t mask = (size < 8) ? ((uint64_t) 1 << (size * 8)) - 1 : ~(uint64_t) 0;
+            if ((data & mask) != (entry.datamatch & mask)) {
+                continue;
+            }
+        }
+        return entry.fd;
+    }
+    return -1;
+}
+
 int VM::setTSSAddress(uint64_t tss_addr) {
 #ifdef SE_KVM_DEBUG_INTERFACE
     printf("Setting tss addr %#" PRIx64 " not implemented yet\n", tss_addr);
@@ -191,10 +212,53 @@ int VM::getClock(kvm_clock_data *clock) {
 
 int VM::ioEventFD(kvm_ioeventfd *event) {
 #ifdef SE_KVM_DEBUG_INTERFACE
-    printf("kvm_ioeventd datamatch=%#llx addr=%#llx len=%d fd=%d flags=%#" PRIx32 "\n", event->datamatch, event->addr,
+    printf("kvm_ioeventfd datamatch=%#llx addr=%#llx len=%d fd=%d flags=%#" PRIx32 "\n", event->datamatch, event->addr,
            event->len, event->fd, event->flags);
 #endif
-    return -1;
+
+    if (event->flags & ~KVM_IOEVENTFD_VALID_FLAG_MASK) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (event->flags & KVM_IOEVENTFD_FLAG_VIRTIO_CCW_NOTIFY) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (event->len != 0 && event->len != 1 && event->len != 2 && event->len != 4 && event->len != 8) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    bool is_pio = (event->flags & KVM_IOEVENTFD_FLAG_PIO) != 0;
+    bool has_datamatch = (event->flags & KVM_IOEVENTFD_FLAG_DATAMATCH) != 0;
+    bool is_deassign = (event->flags & KVM_IOEVENTFD_FLAG_DEASSIGN) != 0;
+
+    auto &eventfds = is_pio ? m_ioeventfds_pio : m_ioeventfds_mmio;
+
+    if (is_deassign) {
+        for (auto it = eventfds.begin(); it != eventfds.end(); ++it) {
+            if (it->addr == event->addr && it->len == event->len && it->has_datamatch == has_datamatch &&
+                (!has_datamatch || it->datamatch == event->datamatch) && it->fd == event->fd) {
+                eventfds.erase(it);
+                return 0;
+            }
+        }
+        errno = ENOENT;
+        return -1;
+    }
+
+    IoEventFdEntry entry;
+    entry.addr = event->addr;
+    entry.datamatch = has_datamatch ? event->datamatch : 0;
+    entry.len = event->len;
+    entry.fd = event->fd;
+    entry.is_pio = is_pio;
+    entry.has_datamatch = has_datamatch;
+
+    eventfds.push_back(entry);
+    return 0;
 }
 
 int VM::diskReadWrite(kvm_disk_rw *d) {

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -207,8 +207,10 @@ int VM::getDirtyLog(kvm_dirty_log *log) {
     return 0;
 }
 
-int VM::setIdentityMapAddress(uint64_t addr) {
-    assert(false && "Not implemented");
+int VM::setIdentityMapAddress(uint64_t *addr) {
+    // XXX: fixme
+    printf("setIdentityMapAddress %#" PRIx64 " not implemented yet\n", *addr);
+    return 0;
 }
 
 int VM::setClock(kvm_clock_data *clock) {
@@ -351,7 +353,7 @@ int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
         } break;
 
         case KVM_SET_IDENTITY_MAP_ADDR: {
-            ret = setIdentityMapAddress(arg1);
+            ret = setIdentityMapAddress((uint64_t *) arg1);
         } break;
 
         case KVM_GET_DIRTY_LOG: {

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -323,6 +323,15 @@ int VM::handle_irq_fd(const struct kvm_irqfd *irqfd) {
     return 0;
 }
 
+int VM::set_gsi_routing(const kvm_irq_routing *routing) {
+    m_gsi_routes.clear();
+    for (uint32_t i = 0; i < routing->nr; ++i) {
+        const auto &entry = routing->entries[i];
+        m_gsi_routes[entry.gsi].push_back(entry);
+    }
+    return 0;
+}
+
 int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
     int ret = -1;
     switch ((uint32_t) request) {
@@ -396,6 +405,10 @@ int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
 
         case KVM_IRQFD: {
             ret = handle_irq_fd((const struct kvm_irqfd *) arg1);
+        } break;
+
+        case KVM_SET_GSI_ROUTING: {
+            ret = set_gsi_routing((const kvm_irq_routing *) arg1);
         } break;
 
         default: {

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -354,7 +354,9 @@ int VM::irq_line(const kvm_irq_level *level) {
     auto lapic = m_cpu->lapic();
     for (const auto &entry : it->second) {
         if (entry.type == KVM_IRQ_ROUTING_MSI) {
-            lapic->deliver_msi(entry.u.msi.address_lo, entry.u.msi.address_hi, entry.u.msi.data);
+            m_cpu->task_runner().run_on_thread([lapic, entry]() {
+                lapic->deliver_msi(entry.u.msi.address_lo, entry.u.msi.address_hi, entry.u.msi.data);
+            });
         } else {
             fprintf(stderr, "libs2e: KVM_IRQ_LINE gsi=%d unsupported routing type %d\n", gsi, entry.type);
         }
@@ -444,9 +446,7 @@ int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
 
         case KVM_IRQ_LINE: {
             m_cpu->request_exit_cpu_loop();
-            m_cpu->lock();
             ret = irq_line((const kvm_irq_level *) arg1);
-            m_cpu->unlock();
         } break;
 
         case KVM_CREATE_IRQCHIP: {

--- a/libs2e/src/s2e-kvm-vm.cpp
+++ b/libs2e/src/s2e-kvm-vm.cpp
@@ -318,6 +318,11 @@ int VM::setClockScalePointer(unsigned *scale) {
 #endif
 }
 
+int VM::handle_irq_fd(const struct kvm_irqfd *irqfd) {
+    printf("Unhandled handle_irq_fd fd=%d gsi=%d flags=%#" PRIx32 "\n", irqfd->fd, irqfd->gsi, irqfd->flags);
+    return 0;
+}
+
 int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
     int ret = -1;
     switch ((uint32_t) request) {
@@ -387,6 +392,10 @@ int VM::sys_ioctl(int fd, int request, uint64_t arg1) {
 
         case KVM_SET_CLOCK_SCALE: {
             ret = setClockScalePointer((unsigned *) arg1);
+        } break;
+
+        case KVM_IRQFD: {
+            ret = handle_irq_fd((const struct kvm_irqfd *) arg1);
         } break;
 
         default: {

--- a/libs2e/src/s2e-kvm-vm.h
+++ b/libs2e/src/s2e-kvm-vm.h
@@ -122,7 +122,6 @@ public:
 
     static std::shared_ptr<VM> create(std::shared_ptr<S2EKVM> &kvm);
 
-    void sendCpuExitSignal();
     virtual int sys_ioctl(int fd, int request, uint64_t arg1);
 
     VirtualDeviceManager &dev_mgr() {

--- a/libs2e/src/s2e-kvm-vm.h
+++ b/libs2e/src/s2e-kvm-vm.h
@@ -57,6 +57,8 @@ private:
     std::vector<IoEventFdEntry> m_ioeventfds_pio;
     std::vector<IoEventFdEntry> m_ioeventfds_mmio;
 
+    bool m_split_irqchip = false;
+
     VM(std::shared_ptr<S2EKVM> &kvm) : m_kvm(kvm) {
     }
 

--- a/libs2e/src/s2e-kvm-vm.h
+++ b/libs2e/src/s2e-kvm-vm.h
@@ -114,6 +114,7 @@ private:
     int setClockScalePointer(unsigned *scale);
     int handle_irq_fd(const struct kvm_irqfd *irqfd);
     int set_gsi_routing(const kvm_irq_routing *routing);
+    int irq_line(const kvm_irq_level *level);
 
 public:
     virtual ~VM() {

--- a/libs2e/src/s2e-kvm-vm.h
+++ b/libs2e/src/s2e-kvm-vm.h
@@ -26,6 +26,8 @@
 
 #include <cpu/kvm.h>
 #include <inttypes.h>
+#include <unordered_map>
+#include <vector>
 
 #include "FileDescriptorManager.h"
 #include "hw/manager.h"
@@ -33,6 +35,15 @@
 
 namespace s2e {
 namespace kvm {
+
+struct IoEventFdEntry {
+    uint64_t addr;
+    uint64_t datamatch;
+    uint32_t len;
+    int fd;
+    bool is_pio;
+    bool has_datamatch;
+};
 
 class VCPU;
 
@@ -42,6 +53,9 @@ private:
     std::shared_ptr<VCPU> m_cpu;
 
     VirtualDeviceManager m_dev_mgr;
+
+    std::vector<IoEventFdEntry> m_ioeventfds_pio;
+    std::vector<IoEventFdEntry> m_ioeventfds_mmio;
 
     VM(std::shared_ptr<S2EKVM> &kvm) : m_kvm(kvm) {
     }
@@ -106,6 +120,8 @@ public:
     VirtualDeviceManager &dev_mgr() {
         return m_dev_mgr;
     }
+
+    int lookupIoEventFd(bool is_pio, uint64_t addr, uint64_t data, unsigned size);
 };
 } // namespace kvm
 } // namespace s2e

--- a/libs2e/src/s2e-kvm-vm.h
+++ b/libs2e/src/s2e-kvm-vm.h
@@ -111,6 +111,7 @@ private:
     int diskReadWrite(kvm_disk_rw *d);
     int deviceSnapshot(kvm_dev_snapshot *s);
     int setClockScalePointer(unsigned *scale);
+    int handle_irq_fd(const struct kvm_irqfd *irqfd);
 
 public:
     virtual ~VM() {

--- a/libs2e/src/s2e-kvm-vm.h
+++ b/libs2e/src/s2e-kvm-vm.h
@@ -59,6 +59,8 @@ private:
 
     bool m_split_irqchip = false;
 
+    int m_maxVcpuId = 0;
+
     VM(std::shared_ptr<S2EKVM> &kvm) : m_kvm(kvm) {
     }
 

--- a/libs2e/src/s2e-kvm-vm.h
+++ b/libs2e/src/s2e-kvm-vm.h
@@ -99,7 +99,7 @@ private:
     ///
     int getDirtyLog(kvm_dirty_log *log);
 
-    int setIdentityMapAddress(uint64_t addr);
+    int setIdentityMapAddress(uint64_t *addr);
 
     int setClock(kvm_clock_data *clock);
     int getClock(kvm_clock_data *clock);

--- a/libs2e/src/s2e-kvm-vm.h
+++ b/libs2e/src/s2e-kvm-vm.h
@@ -58,6 +58,7 @@ private:
     std::vector<IoEventFdEntry> m_ioeventfds_mmio;
 
     bool m_split_irqchip = false;
+    std::unordered_map<uint32_t, std::vector<kvm_irq_routing_entry>> m_gsi_routes;
 
     int m_maxVcpuId = 0;
 
@@ -112,6 +113,7 @@ private:
     int deviceSnapshot(kvm_dev_snapshot *s);
     int setClockScalePointer(unsigned *scale);
     int handle_irq_fd(const struct kvm_irqfd *irqfd);
+    int set_gsi_routing(const kvm_irq_routing *routing);
 
 public:
     virtual ~VM() {

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -342,6 +342,9 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_FORCE_EXIT:
             return 1;
 
+        case KVM_CAP_IRQ_ROUTING:
+            return 4096;          // KVM_MAX_IRQ_ROUTES
+
 #ifdef CONFIG_SYMBEX
         case KVM_CAP_MEM_FIXED_REGION:
         case KVM_CAP_DISK_RW:

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -465,9 +465,10 @@ int S2EKVM::getSupportedCPUID(struct kvm_cpuid2 *cpuid) {
         }
         e->function = s_cpuid_entries[i][0];
 
-#ifdef SE_KVM_DEBUG_CPUID
-        print_cpuid2(e);
-#endif
+        libcpu_log_mask(CPU_LOG_KVM,
+                        "cpuid function=%#010" PRIx32 " index=%#010" PRIx32 " flags=%#010" PRIx32 " eax=%#010" PRIx32
+                        " ebx=%#010" PRIx32 " ecx=%#010" PRIx32 " edx=%#010" PRIx32 "\n",
+                        e->function, e->index, e->flags, e->eax, e->ebx, e->ecx, e->edx);
     }
 
     return 0;

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -330,6 +330,7 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_SPLIT_IRQCHIP:
         case KVM_CAP_SET_IDENTITY_MAP_ADDR:
         case KVM_CAP_VCPU_EVENTS:
+        case KVM_CAP_IRQFD:
 
         // We don't really need to support this call, just pretend that we do.
         // The real exit will be done through our custom KVM_CAP_FORCE_EXIT.

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -174,9 +174,6 @@ IFilePtr S2EKVM::create() {
 void S2EKVM::cleanup(void) {
     g_s2e_kvm->m_exiting = true;
 
-    while (!g_s2e_kvm->m_timerExited) {
-    }
-
 #ifdef CONFIG_SYMBEX
     if (g_s2e) {
         monitor_close();
@@ -385,10 +382,6 @@ int S2EKVM::createVM() {
 
     m_vm = vm;
 
-    if (initTimerThread() < 0) {
-        exit(-1);
-    }
-
     return g_fdm->registerInterface(vm);
 }
 
@@ -467,62 +460,6 @@ int S2EKVM::getSupportedCPUID(struct kvm_cpuid2 *cpuid) {
 void S2EKVM::sendCpuExitSignal() {
     assert(m_vm);
     m_vm->sendCpuExitSignal();
-}
-
-void *S2EKVM::timerCb(void *param) {
-    auto obj = reinterpret_cast<S2EKVM *>(param);
-
-    while (!obj->m_exiting) {
-        usleep(100 * 1000);
-
-        // Send a signal to exit CPU loop only when no slow KLEE code
-        // is running. Otherwise, there are too many exits and little
-        // progress in the guest.
-        if (timers_state.cpu_clock_scale_factor == 1) {
-            // Required for shutdown, otherwise kvm clients may get stuck
-            // Also required to give a chance timers to run
-
-            obj->sendCpuExitSignal();
-        }
-    }
-
-    obj->m_timerExited = true;
-    return nullptr;
-}
-
-int S2EKVM::initTimerThread(void) {
-    int ret;
-    pthread_attr_t attr;
-    sigset_t signals;
-
-    ret = pthread_attr_init(&attr);
-    if (ret < 0) {
-        fprintf(stderr, "Could not init thread attributes\n");
-        goto err1;
-    }
-
-    ret = pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-    if (ret < 0) {
-        fprintf(stderr, "Could not set detached state for thread\n");
-        goto err1;
-    }
-
-    ret = pthread_create(&m_timerThread, &attr, timerCb, this);
-    if (ret < 0) {
-        fprintf(stderr, "could not create timer thread\n");
-        goto err1;
-    }
-
-    sigfillset(&signals);
-    if (pthread_sigmask(SIG_BLOCK, &signals, NULL) < 0) {
-        fprintf(stderr, "could not block signals on the timer thread\n");
-        goto err1;
-    }
-
-    pthread_attr_destroy(&attr);
-
-err1:
-    return ret;
 }
 
 int S2EKVM::sys_ioctl(int fd, int request, uint64_t arg1) {

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -331,6 +331,7 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_SET_IDENTITY_MAP_ADDR:
         case KVM_CAP_VCPU_EVENTS:
         case KVM_CAP_IRQFD:
+        case KVM_CAP_IRQCHIP:
 
         // We don't really need to support this call, just pretend that we do.
         // The real exit will be done through our custom KVM_CAP_FORCE_EXIT.

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -329,6 +329,7 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_IOEVENTFD_ANY_LENGTH:
         case KVM_CAP_SPLIT_IRQCHIP:
         case KVM_CAP_SET_IDENTITY_MAP_ADDR:
+        case KVM_CAP_VCPU_EVENTS:
 
         // We don't really need to support this call, just pretend that we do.
         // The real exit will be done through our custom KVM_CAP_FORCE_EXIT.

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -473,11 +473,6 @@ int S2EKVM::getSupportedCPUID(struct kvm_cpuid2 *cpuid) {
     return 0;
 }
 
-void S2EKVM::sendCpuExitSignal() {
-    assert(m_vm);
-    m_vm->sendCpuExitSignal();
-}
-
 int S2EKVM::sys_ioctl(int fd, int request, uint64_t arg1) {
     int ret = -1;
 

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -327,6 +327,7 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_DEBUGREGS:
         case KVM_CAP_IOEVENTFD:
         case KVM_CAP_IOEVENTFD_ANY_LENGTH:
+        case KVM_CAP_SPLIT_IRQCHIP:
 
         // We don't really need to support this call, just pretend that we do.
         // The real exit will be done through our custom KVM_CAP_FORCE_EXIT.

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -328,6 +328,7 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_IOEVENTFD:
         case KVM_CAP_IOEVENTFD_ANY_LENGTH:
         case KVM_CAP_SPLIT_IRQCHIP:
+        case KVM_CAP_SET_IDENTITY_MAP_ADDR:
 
         // We don't really need to support this call, just pretend that we do.
         // The real exit will be done through our custom KVM_CAP_FORCE_EXIT.

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -332,6 +332,9 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_VCPU_EVENTS:
         case KVM_CAP_IRQFD:
         case KVM_CAP_IRQCHIP:
+        case KVM_CAP_INTERNAL_ERROR_DATA:   // TODO
+        case KVM_CAP_SIGNAL_MSI:            // TODO
+        case KVM_CAP_X86_ROBUST_SINGLESTEP: // TODO
 
         // We don't really need to support this call, just pretend that we do.
         // The real exit will be done through our custom KVM_CAP_FORCE_EXIT.
@@ -343,8 +346,11 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_FORCE_EXIT:
             return 1;
 
+        case KVM_CAP_MCE:
+            return 10;
+
         case KVM_CAP_IRQ_ROUTING:
-            return 4096;          // KVM_MAX_IRQ_ROUTES
+            return 4096; // KVM_MAX_IRQ_ROUTES
 
 #ifdef CONFIG_SYMBEX
         case KVM_CAP_MEM_FIXED_REGION:
@@ -513,6 +519,10 @@ int S2EKVM::sys_ioctl(int fd, int request, uint64_t arg1) {
             ret = 0;
         } break;
 #endif
+
+        case KVM_X86_GET_MCE_CAP_SUPPORTED: {
+            ret = 0; // MSR_IA32_MCG_CAP is not supported, so no MCE support.
+        } break;
 
         default: {
             fprintf(stderr, "libs2e: unknown KVM IOCTL %x\n", request);

--- a/libs2e/src/s2e-kvm.cpp
+++ b/libs2e/src/s2e-kvm.cpp
@@ -325,6 +325,8 @@ int S2EKVM::checkExtension(int capability) {
         case KVM_CAP_MAX_VCPUS:
         case KVM_CAP_XSAVE:
         case KVM_CAP_DEBUGREGS:
+        case KVM_CAP_IOEVENTFD:
+        case KVM_CAP_IOEVENTFD_ANY_LENGTH:
 
         // We don't really need to support this call, just pretend that we do.
         // The real exit will be done through our custom KVM_CAP_FORCE_EXIT.

--- a/libs2e/src/s2e-kvm.h
+++ b/libs2e/src/s2e-kvm.h
@@ -69,8 +69,6 @@ private:
 
     static void cleanup();
 
-    void sendCpuExitSignal();
-
     int getApiVersion(void);
     int createVM();
     int getMSRIndexList(kvm_msr_list *list);

--- a/libs2e/src/s2e-kvm.h
+++ b/libs2e/src/s2e-kvm.h
@@ -53,9 +53,7 @@ private:
     static const char *s_cpuModel;
     static const bool s_is64;
 
-    pthread_t m_timerThread;
     bool m_exiting = false;
-    volatile bool m_timerExited = false;
     cpuid_t m_cpuid;
 
     std::shared_ptr<VM> m_vm;
@@ -64,7 +62,6 @@ private:
     static std::string getBitcodeLibrary(const std::string &dir);
 #endif
 
-    static void *timerCb(void *param);
     void init(void);
     void initLogLevel(void);
 
@@ -89,7 +86,6 @@ public:
     virtual int sys_ioctl(int fd, int request, uint64_t arg1);
 
     int checkExtension(int capability);
-    int initTimerThread(void);
 
     bool exiting() const {
         return m_exiting;

--- a/libs2e/src/task_runner.h
+++ b/libs2e/src/task_runner.h
@@ -1,0 +1,72 @@
+///
+/// Copyright (C) 2026, Vitaly Chipounov
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+///
+
+#ifndef S2E_TASK_RUNNER_H
+#define S2E_TASK_RUNNER_H
+
+#include <pthread.h>
+
+#include <deque>
+#include <functional>
+#include <mutex>
+
+class TaskRunner {
+private:
+    pthread_t m_thread;
+    std::mutex m_mutex;
+    std::deque<std::function<void()>> m_tasks;
+
+public:
+    TaskRunner() : m_thread(pthread_self()) {};
+    ~TaskRunner() = default;
+
+    bool run_on_thread() {
+        if (!pthread_equal(pthread_self(), m_thread)) {
+            return false;
+        }
+
+        std::deque<std::function<void()>> tasks;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            tasks.swap(m_tasks);
+        }
+
+        for (auto &task : tasks) {
+            task();
+        }
+
+        return true;
+    }
+
+    bool run_on_thread(std::function<void()> task) {
+        if (!pthread_equal(pthread_self(), m_thread)) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_tasks.push_back(std::move(task));
+            return false;
+        }
+
+        task();
+        return true;
+    }
+};
+
+#endif

--- a/libs2ecore/src/S2EExecutor.cpp
+++ b/libs2ecore/src/S2EExecutor.cpp
@@ -147,7 +147,7 @@ namespace {
     cl::opt<unsigned>
     ClockSlowDown("clock-slow-down",
             cl::desc("Slow down factor when interpreting LLVM code"),
-            cl::init(101));
+            cl::init(1009));
 
     cl::opt<unsigned>
     ClockSlowDownConcrete("clock-slow-down-concrete",
@@ -946,13 +946,9 @@ bool S2EExecutor::finalizeTranslationBlockExec(S2EExecutionState *state) {
 
 void S2EExecutor::updateClockScaling() {
     int scaling = ClockSlowDownConcrete;
-
     if (g_s2e_fast_concrete_invocation) {
         // Concrete execution
-        scaling = timers_state.cpu_clock_scale_factor / 2;
-        if (scaling == 0) {
-            scaling = ClockSlowDownConcrete;
-        }
+        scaling = ClockSlowDownConcrete;
     } else {
         // Symbolic execution
         scaling = UseFastHelpers ? ClockSlowDownFastHelpers : ClockSlowDown;

--- a/libs2eplugins/src/s2e/Plugins/OSMonitors/Windows/WindowsCrashMonitor.cpp
+++ b/libs2eplugins/src/s2e/Plugins/OSMonitors/Windows/WindowsCrashMonitor.cpp
@@ -38,12 +38,10 @@ namespace s2e {
 namespace plugins {
 
 S2E_DEFINE_PLUGIN(WindowsCrashMonitor, "This plugin aggregates various sources of Windows crashes", "",
-                  "WindowsMonitor", "WindowsCrashDumpGenerator", "BlueScreenInterceptor");
+                  "WindowsMonitor");
 
 void WindowsCrashMonitor::initialize() {
     m_windowsMonitor = s2e()->getPlugin<WindowsMonitor>();
-    m_bsodInterceptor = s2e()->getPlugin<BlueScreenInterceptor>();
-    m_bsodGenerator = s2e()->getPlugin<WindowsCrashDumpGenerator>();
 
     auto cfg = s2e()->getConfig();
 
@@ -62,7 +60,21 @@ void WindowsCrashMonitor::initialize() {
     m_maxCrashDumpCount = cfg->getInt(getConfigKey() + ".maxCrashDumps", 10);
     *m_crashCount.get() = 0;
 
-    m_bsodInterceptor->onBlueScreen.connect(sigc::mem_fun(*this, &WindowsCrashMonitor::onBlueScreen));
+    if (m_generateDumpOnKernelCrash) {
+        m_bsodInterceptor = s2e()->getPlugin<BlueScreenInterceptor>();
+        if (!m_bsodInterceptor) {
+            getWarningsStream() << "BlueScreenInterceptor is required for generateCrashDumpOnKernelCrash\n";
+            exit(-1);
+        }
+
+        m_bsodGenerator = s2e()->getPlugin<WindowsCrashDumpGenerator>();
+        if (!m_bsodGenerator) {
+            getWarningsStream() << "WindowsCrashDumpGenerator is required for generateCrashDumpOnKernelCrash\n";
+            exit(-1);
+        }
+
+        m_bsodInterceptor->onBlueScreen.connect(sigc::mem_fun(*this, &WindowsCrashMonitor::onBlueScreen));
+    }
 }
 
 void WindowsCrashMonitor::generateCrashDump(S2EExecutionState *state, const vmi::windows::BugCheckDescription *info,

--- a/libtcg/include/tcg/tcg-llvm.h
+++ b/libtcg/include/tcg/tcg-llvm.h
@@ -114,6 +114,7 @@ private:
     llvm::Instruction *m_noop;
     llvm::Value *m_eip;
     llvm::Value *m_ccop;
+    llvm::BasicBlock *m_abortBB;
 
     static unsigned m_eip_last_gep_index;
 

--- a/libtcg/include/tcg/tcg.h
+++ b/libtcg/include/tcg/tcg.h
@@ -595,6 +595,7 @@ struct TCGContext {
 
 #ifdef CONFIG_SYMBEX
     unsigned tlbe_offset_symbex_addend;
+    unsigned env_offset_se_tb_abort;
 #endif
 
     unsigned target_page_bits;

--- a/libtcg/include/tcg/utils/log.h
+++ b/libtcg/include/tcg/utils/log.h
@@ -43,6 +43,8 @@ typedef int (*fprintf_function)(FILE *f, const char *fmt, ...);
 #define CPU_LOG_RESET      (1 << 9)
 #define CPU_LOG_LLVM_IR    (1 << 10)
 #define CPU_LOG_LLVM_ASM   (1 << 11)
+#define CPU_LOG_KVM        (1 << 12)
+#define CPU_LOG_KVM_IO     (1 << 13)
 
 /* Log settings checking macros: */
 

--- a/libtcg/src/tcg-llvm.cpp
+++ b/libtcg/src/tcg-llvm.cpp
@@ -1172,6 +1172,7 @@ Function *TCGLLVMTranslator::generateCode(TCGContext *s, TranslationBlock *tb) {
 
     m_tbFunction = createTbFunction(name);
     m_tbFunction->addFnAttr(Attribute::AlwaysInline);
+    m_abortBB = nullptr;
 
     BasicBlock *basicBlock = BasicBlock::Create(getContext(), "entry", m_tbFunction);
     m_builder.SetInsertPoint(basicBlock);
@@ -1218,6 +1219,25 @@ Function *TCGLLVMTranslator::generateCode(TCGContext *s, TranslationBlock *tb) {
                     valueToStore = ConstantInt::get(wordType(m_tcgContext->env_sizeof_ccop * 8), cc_op);
                     generateQemuCpuStore(args, m_tcgContext->env_sizeof_ccop * 8, valueToStore);
                 }
+
+                // Check env->se_tb_abort: set by tb_phys_invalidate() when self-modifying
+                // code invalidates the currently running TB. The eip has already been stored
+                // above, so returning here lets the CPU loop re-fetch at the correct PC.
+                auto *abortPtr = generateCpuStatePtr(m_tcgContext->env_offset_se_tb_abort, sizeof(uint32_t));
+                auto *abortVal = m_builder.CreateLoad(intType(32), abortPtr);
+                auto *cond = m_builder.CreateICmpNE(abortVal, ConstantInt::get(intType(32), 0));
+
+                if (!m_abortBB) {
+                    m_abortBB = BasicBlock::Create(getContext(), "tb_abort", m_tbFunction);
+                    IRBuilder<>::InsertPointGuard guard(m_builder);
+                    m_builder.SetInsertPoint(m_abortBB);
+                    m_builder.CreateRet(ConstantInt::get(wordType(), 0));
+                }
+
+                auto *continueBB = BasicBlock::Create(getContext(), "tb_continue", m_tbFunction);
+                m_builder.CreateCondBr(cond, m_abortBB, continueBB);
+
+                m_builder.SetInsertPoint(continueBB);
             } break;
 #endif
 

--- a/libtcg/src/utils/log.c
+++ b/libtcg/src/utils/log.c
@@ -60,6 +60,8 @@ const CPULogItem cpu_log_items[] = {
 #ifdef CONFIG_SYMBEX
     {CPU_LOG_LLVM_IR, "llvm_ir", "show generated LLVM IR code"},
 #endif
+    {CPU_LOG_KVM, "kvm", "log kvm calls"},
+    {CPU_LOG_KVM_IO, "kvm_io", "log kvm i/o (mmio, ioport)"},
     {0, NULL, NULL},
 };
 

--- a/libvmi/src/WindowsCrashDumpGenerator.cpp
+++ b/libvmi/src/WindowsCrashDumpGenerator.cpp
@@ -270,12 +270,14 @@ bool WindowsCrashDumpGenerator::writeHeader(HEADER *Header, const CONTEXT *conte
 }
 
 bool WindowsCrashDumpGenerator::generate(const BugCheckDescription &bugDesc, void *context, unsigned contextSize) {
-    uint8_t buffer[0x2000];
+    uint8_t buffer[0x2000] = {0};
 
     if (bugDesc.headerSize <= sizeof(buffer)) {
         if (!m_virtualMemory->readb(buffer, bugDesc.headerSize, bugDesc.guestHeader)) {
             return false;
         }
+    } else {
+        return false;
     }
 
     if (bugDesc.headerSize == 0x2000) {

--- a/scripts/windows/Setup-DevHost.ps1
+++ b/scripts/windows/Setup-DevHost.ps1
@@ -13,7 +13,7 @@ choco install -y rsync
 choco install -y visualstudio2019community
 choco install -y visualstudio2019-workload-nativedesktop  --package-parameters "--includeOptional --includeRecommended"
 
-"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\community" --add Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --add Microsoft.VisualStudio.Component.WinXP --quiet
+& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\community" --add Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre --add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --add Microsoft.VisualStudio.Component.WinXP --quiet
 
 choco install -y windows-sdk-8.1
 

--- a/testsuite/basic12-256paths/Makefile
+++ b/testsuite/basic12-256paths/Makefile
@@ -1,0 +1,46 @@
+# Copyright (c) 2019, Cyberhaven
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+TARGET=basic12-256paths
+SOURCE=main.c
+
+GCC_LINUX=gcc
+GCC_WINDOWS64=x86_64-w64-mingw32-gcc
+GCC_WINDOWS32=i686-w64-mingw32-gcc
+
+CFLAGS:=-O0 -g -Wall -std=c99 $(CFLAGS)
+
+linux64-$(TARGET): $(SOURCE)
+	$(GCC_LINUX) -m64 $(CFLAGS) -o "$@" "$^"
+
+linux32-$(TARGET): $(SOURCE)
+	$(GCC_LINUX) -m32 $(CFLAGS) -o "$@" "$^"
+
+windows64-$(TARGET).exe: $(SOURCE)
+	$(GCC_WINDOWS64) -m64 $(CFLAGS) -o "$@" "$^"
+
+windows32-$(TARGET).exe: $(SOURCE)
+	$(GCC_WINDOWS32) -m32 $(CFLAGS) -o "$@" "$^"
+
+TARGETS=linux64-$(TARGET) linux32-$(TARGET) windows64-$(TARGET).exe windows32-$(TARGET).exe
+
+all: $(TARGETS)
+clean:
+	rm -f $(TARGETS)

--- a/testsuite/basic12-256paths/config.yml
+++ b/testsuite/basic12-256paths/config.yml
@@ -1,0 +1,11 @@
+test:
+    description: "Checks that basic symbolic execution works by forking 256 paths"
+
+    target_arguments:
+        - ["@@"]
+
+    targets:
+        - windows64-basic12-256paths.exe
+        - windows32-basic12-256paths.exe
+        - linux32-basic12-256paths
+        - linux64-basic12-256paths

--- a/testsuite/basic12-256paths/main.c
+++ b/testsuite/basic12-256paths/main.c
@@ -1,0 +1,63 @@
+/// Copyright (c) 2019, Cyberhaven
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#include <s2e/s2e.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    int ret = 0;
+    FILE *fp = NULL;
+    unsigned char bytes[8] = {0};
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s input_file\n", argv[0]);
+        ret = 1;
+        goto err;
+    }
+
+    fp = fopen(argv[1], "rb");
+    if (!fp) {
+        fprintf(stderr, "Could not open %s\n", argv[1]);
+        ret = 2;
+        goto err;
+    }
+
+    if (fread(bytes, 8, 1, fp) != 1) {
+        fprintf(stderr, "Could not read bytes from file\n");
+        ret = 3;
+        goto err;
+    }
+
+    // 8 independent byte checks produce 2^8 = 256 paths
+    for (int i = 0; i < 8; i++) {
+        if (bytes[i]) {
+            s2e_printf("Byte %d is non-zero\n", i);
+        } else {
+            s2e_printf("Byte %d is zero\n", i);
+        }
+    }
+
+err:
+    if (fp) {
+        fclose(fp);
+    }
+
+    return ret;
+}

--- a/testsuite/basic12-256paths/run-tests.tpl
+++ b/testsuite/basic12-256paths/run-tests.tpl
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+{% include 'common-run.sh.tpl' %}
+
+s2e run -n {{ project_name }}
+
+echo === Checking that program forked 256 paths
+grep -q "Byte 0 is non-zero" $S2E_LAST/debug.txt
+grep -q "Byte 0 is zero" $S2E_LAST/debug.txt
+grep -q "Byte 7 is non-zero" $S2E_LAST/debug.txt
+grep -q "Byte 7 is zero" $S2E_LAST/debug.txt
+
+PATH_COUNT=$(grep -c "Byte 7 is" $S2E_LAST/debug.txt)
+if [ "$PATH_COUNT" -ne 256 ]; then
+    echo "Expected 256 paths, got $PATH_COUNT"
+    exit 1
+fi
+
+check_coverage {{project_name}} 60
+
+s2e forkprofile {{ project_name }} > $S2E_LAST/forkprofile.txt
+grep -q -i main.c $S2E_LAST/forkprofile.txt

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-$boxes = ["debian/bookworm64", "debian/testing64", "generic/ubuntu2204", "bento/ubuntu-24.04"]
+$boxes = ["debian/bookworm64", "debian/trixie64", "generic/ubuntu2204", "bento/ubuntu-24.04"]
 
 Vagrant.configure("2") do |config|
   $boxes.to_enum.with_index(1).each do |box,i|

--- a/vagrant/provision-user.sh
+++ b/vagrant/provision-user.sh
@@ -20,31 +20,50 @@
 # SOFTWARE.
 
 set -xe
-cd /mnt/disk
+
+ROOTDIR=/mnt/disk
+
+REPO_BRANCH=master
+# SCRIPTS_BRANCH=qemu-10.2
+# S2EENV_BRANCH=qemu-10.2
+# LIBS2E_BRANCH=issue/qemu-10.2-tmp
+# QEMU_BRANCH=stable-10.2-se
+
+cd "$ROOTDIR"
 
 if [ ! -d s2e-env ]; then
     git clone https://github.com/s2e/s2e-env.git
 fi
 
-cd s2e-env
+cd "$ROOTDIR/s2e-env"
 
-# Checkout custom s2e-env branch here
-# git checkout issue/xxx-debian
+if [ "x$S2EENV_BRANCH" != "x" ]; then
+    git checkout "$S2EENV_BRANCH"
+fi
 
 python3 -m venv venv
 . venv/bin/activate
 pip install --upgrade pip wheel
-
 pip install .
-
 . venv/bin/activate
 
-cd /mnt/disk
-s2e init env
-cd env/source/s2e
+cd "$ROOTDIR"
+s2e init -mb "$REPO_BRANCH" env
 
-# Checkout custom s2e branch here
-# git checkout issue/xxx-debian
+if [ "x$LIBS2E_BRANCH" != "x" ]; then
+    cd "$ROOTDIR/env/source/s2e"
+    git checkout "$LIBS2E_BRANCH"
+fi
 
-cd /mnt/disk/env
+if [ "x$SCRIPTS_BRANCH" != "x" ]; then
+    cd "$ROOTDIR/env/source/scripts"
+    git checkout "$SCRIPTS_BRANCH"
+fi
+
+if [ "x$QEMU_BRANCH" != "x" ]; then
+    cd "$ROOTDIR/env/source/qemu"
+    git checkout "$QEMU_BRANCH"
+fi
+
+cd "$ROOTDIR/env"
 s2e build


### PR DESCRIPTION
This PR adds virtual APIC support required for QEMU 10.2. This version does not support APIC emulation anymore and requires the kernel to handle it. S2E must therefore emulate it itself. QEMU must now be started with `-accel accel=kvm,kernel-irqchip=split` instead of `--enable-kvm`. The latter requres full IRQ chip emulation, whereas split mode only requires APIC emulation.